### PR TITLE
Remove Android dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,29 +32,110 @@ buildscript {
   }
 }
 ```
-Then apply the plugin in your buildscript **after the android plugin** via:  
+Then apply the plugin in your build script via:
 ```gradle
 apply plugin: 'com.novoda.build-properties'
 ```
 
 ## Simple usage
-Add a `buildProperties` configuration to your android buildscript listing
-all the properties files you intend to reference in your `android` configuration:
+Add a `buildProperties` configuration to your build script listing
+all the properties files you intend to reference later on:
 ```gradle
 buildProperties {
     secrets {
         file project.file('secrets.properties')
     }
 }
-
-android {
-    ...
-}
 ```
 where `secrets.properties` is a properties file that can now be referenced
-in the buildscript as `buildProperties.secrets`.   
+in the build script as `buildProperties.secrets`. Entries in such file can be
+accessed via the `getAt` operator:
+```gradle
+Entry entry = buildProperties.secrets['aProperty']
+```
+
+The value of an `Entry`` can be retrieved via one of its typed accessors:
+
+- `boolean enabled = buildProperties.secrets['x'].boolean`
+- `int count = buildProperties.secrets['x'].int`
+- `double rate = buildProperties.secrets['x'].double`
+- `String label = buildProperties.secrets['x'].string`
+
+Is important to note that values are lazily accessed too (via the internal closure provided in `Entry`).
+Trying to access the value of a specific property could generate an exception
+if the key is missing in the provided properties file, eg:
+```
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+A problem occurred configuring project ':app'.
+> No value defined for property 'notThere' in 'secrets' properties (/Users/toto/novoda/spikes/BuildPropertiesPlugin/sample/properties/secrets.properties)
+
+```
 
 ## Features
+
+#### Fallback support
+If a property cannot be found an exception is thrown. It's possible to provide a fallback
+value for a given `Entry` via the `or()` operator, defined as:
+
+| | Example |
+|----|----|
+|another `Entry` | `buildProperties.secrets['notThere'].or(buildProperties.secrets['fallback'])` |
+|a `Closure` | `buildProperties.secrets['notThere'].or({ Math.random() })` |
+|a value | `buildProperties.secrets['notThere'].or('fallback')` |
+
+If the whole fallback chain evaluation fails then a `CompositeException` is thrown listing all
+the causes in the chain, eg:
+
+```
+A problem occurred while evaluating entry:
+- exception message 1
+- exception message 2
+- exception message 3
+
+```
+
+#### Override properties at build time
+A property from any file listed in `buildProperties` can be overridden at
+build time specifying a new value as project property (ie: `-PapiKey=newValue`).
+
+#### Properties inheritance
+It might be useful to have properties files that can recursively include
+another properties files (specified via an `include` property).
+Inherited properties can be overridden by the including set, just redefine
+the property in the file and its value will be used instead of the one
+from the included set.
+
+#### Other built-in `Entry` sets
+It's possible to access a system enviroment variable as `Entry` via a predefined set of entries, ie:
+
+```groovy
+buildProperties.env['FOO']
+```
+Such entries are particularly handy when used alongside the `Entry.or()` operator in order to provide
+fallback values.
+
+#### More on loading properties
+If the specified file is not found an exception is thrown at build time as soon as one of its properties is evaluated.
+You can specify a custom error message to provide the user with more information, eg:
+```gradle
+buildProperties {
+    secrets {
+        file rootProject.file('secrets.properties'), '''
+           This file should contain the following properties:
+           - fabricApiKey: API key for Fabric
+           - googleMapsApiKey: API key for Google Maps
+        '''
+    }
+}
+```
+
+
+## Android-specific features
+
+When applying the `gradle-build-properties-plugin` to an Android project you get access to and
+ additional set of poerful features.
 
 #### 1. Store a property value into your `BuildConfig`
 In any product flavor configuration (or `defaultConfig`) you can use
@@ -93,9 +174,7 @@ The plugin will automatically retrieve all the needed fields from the
 properties file. Note: the path of the keystore file is considered relative
 to the path of the specified properties file.
 
-## Bonus
-
-#### Typed `buildConfigField` / `resValue`
+#### 4. Typed `buildConfigField` / `resValue`
 The plugin enhances the `buildConfigField` and `resValue` facilities to
 enforce types. To generate a string field in your `BuildConfig` you used to write:
 ```gradle
@@ -117,74 +196,3 @@ The full list of new typed facilities is as follows:
 |`resValueInt`| `resValueInt 'debug_test_int', 100`|
 |`resValueBoolean` | `resValueBoolean 'debug_test_bool', true`|
 |`resValueString` | `resValueString 'debug_test_string', 'dunno bro...'`|
-
-#### Fallback support
-If a property cannot be found an exception is thrown. It's possible to provide a fallback
-value for a given `Entry` via the `or()` operator, defined as:
-
-| | Example |
-|----|----|
-|another `Entry` | `buildProperties.secrets['notThere'].or(buildProperties.secrets['fallback'])` |
-|a `Closure` | `buildProperties.secrets['notThere'].or({ Math.random() })` |
-|a value | `buildProperties.secrets['notThere'].or('fallback')` |
-
-If the whole fallback chain evaluation fails a `CompositeException` is thrown listing all
-the causes in the chain, eg:
-
-```
-A problem occurred while evaluating entry:
-- exception message 1
-- exception message 2
-- exception message 3
-
-```
-
-#### Override properties at build time
-A property from any file listed in `buildProperties` can be overridden at
-build time specifying a new value as project property (ie: `-PapiKey=newValue`).
-
-#### Properties inheritance
-It might be useful to have properties files that can recursively include
-another properties files (specified via an `include` property).
-Inherited properties can be overridden by the including set, just redefine
-the property in the file and its value will be used instead of the one
-from the included set.
-
-#### Other built-in `Entry` sets
-It's possible to access a system enviroment variable as `Entry` via a predefined set of entries, ie:
-
-```groovy
-buildProperties.env['FOO']
-```
-Such entries are particularly handy when used alongside the `Entry.or()` operator in order to provide
-fallback values.
-
-#### More on loading properties
-If the specified file is not found an exception is thrown at build time as soon as one of its properties is evaluated.
-You can specify a custom error message to provide the user with more information.
-
-Given a `BuildProperties` instance one of its entries can be retrieved using the `getAt` operator:
-
-```gradle
-Entry entry = buildProperties.secrets['aProperty']
-```
-
-The value of an entry can be retrieved via one of the following typed accessors:
-
-- `entry.getBoolean()`, or `entry.boolean`
-- `entry.getInt()`, or `entry.int`
-- `entry.getDouble()`, or `entry.double`
-- `entry.getString()`, or `entry.string`
-
-If you want to access the raw value (`Object`) you can also use `entry.getValue()`/`entry.value`.
-Is important to note that values are lazily accessed too (via the internal closure provided in `Entry`).
-Trying to access the value of a specific property could generate an exception
-if the key is missing in the provided properties file, eg:
-```
-FAILURE: Build failed with an exception.
-
-* What went wrong:
-A problem occurred configuring project ':app'.
-> No value defined for property 'notThere' in 'secrets' properties (/Users/toto/novoda/spikes/BuildPropertiesPlugin/sample/properties/secrets.properties)
-
-```

--- a/plugin/src/main/groovy/com/novoda/buildproperties/Entry.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/Entry.groovy
@@ -30,7 +30,7 @@ class Entry {
         getValue() as String
     }
 
-    Object getValue() {
+    private Object getValue() {
         value.call()
     }
 

--- a/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesPluginTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesPluginTest.groovy
@@ -45,7 +45,7 @@ public class BuildPropertiesPluginTest {
         }
 
         try {
-            project.buildProperties.foo['any'].value
+            project.buildProperties.foo['any'].string
             fail('Gradle exception not thrown')
         } catch (GradleException e) {
             assertThat(e.getMessage()).endsWith('foo.properties does not exist.')
@@ -63,7 +63,7 @@ public class BuildPropertiesPluginTest {
                     file project.file('foo.properties'), errorMessage
                 }
             }
-            project.buildProperties.foo['any'].value
+            project.buildProperties.foo['any'].string
             fail('Gradle exception not thrown')
         } catch (GradleException e) {
             String message = e.getMessage()

--- a/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesPluginTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesPluginTest.groovy
@@ -26,36 +26,7 @@ public class BuildPropertiesPluginTest {
     }
 
     @Test
-    public void shouldNotApplyPluginWhenAndroidPluginNotApplied() {
-        try {
-            project.apply plugin: BuildPropertiesPlugin
-            fail('Gradle exception not thrown')
-        } catch (GradleException e) {
-            assertThat(e.getCause().getMessage()).isEqualTo('The build-properties plugin can be applied only after the Android plugin')
-        }
-    }
-
-    @Test
-    public void shouldApplyPluginWhenAndroidApplicationPluginApplied() {
-        project.apply plugin: 'com.android.application'
-
-        project.apply plugin: BuildPropertiesPlugin
-
-        assertThat(project.plugins.hasPlugin(BuildPropertiesPlugin)).isTrue()
-    }
-
-    @Test
-    public void shouldApplyPluginWhenAndroidLibraryPluginApplied() {
-        project.apply plugin: 'com.android.library'
-
-        project.apply plugin: BuildPropertiesPlugin
-
-        assertThat(project.plugins.hasPlugin(BuildPropertiesPlugin)).isTrue()
-    }
-
-    @Test
     public void shouldNotFailBuildWhenDefiningPropertiesFromNonExistentFile() {
-        project.apply plugin: 'com.android.library'
         project.apply plugin: BuildPropertiesPlugin
         project.buildProperties {
             foo {
@@ -66,7 +37,6 @@ public class BuildPropertiesPluginTest {
 
     @Test
     public void shouldFailBuildWhenAccessingPropertyFromNonExistentFile() {
-        project.apply plugin: 'com.android.library'
         project.apply plugin: BuildPropertiesPlugin
         project.buildProperties {
             foo {
@@ -84,7 +54,6 @@ public class BuildPropertiesPluginTest {
 
     @Test
     public void shouldProvideSpecifiedErrorMessageWhenAccessingPropertyFromNonExistentFile() {
-        project.apply plugin: 'com.android.library'
         project.apply plugin: BuildPropertiesPlugin
 
         def errorMessage = 'This file should contain the following properties:\n- foo\n- bar'

--- a/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
@@ -30,9 +30,9 @@ class BuildPropertiesTest {
 
     @Test
     public void shouldReturnSamePropertyValueInEntries() {
-        def value = buildProperties['a'].value
+        def value = buildProperties['a'].string
 
-        assertThat(value).isEqualTo(entries['a'].value)
+        assertThat(value).isEqualTo(entries['a'].string)
     }
 
     @Test
@@ -44,12 +44,12 @@ class BuildPropertiesTest {
 
     @Test
     public void shouldReturnDifferentValueFromEntriesWhenPropertyValueOverriddenInProject() {
-        project.ext.a = 1
+        project.ext.a = 'x'
 
-        def value = buildProperties['a'].value
+        def value = buildProperties['a'].string
 
-        assertThat(value).isNotEqualTo(entries['a'].value)
-        assertThat(value).isEqualTo(1)
+        assertThat(value).isNotEqualTo(entries['a'].string)
+        assertThat(value).isEqualTo('x')
     }
 
     static class TestEntries extends Entries {

--- a/plugin/src/test/groovy/com/novoda/buildproperties/FilePropertiesEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/FilePropertiesEntriesTest.groovy
@@ -35,7 +35,7 @@ public class FilePropertiesEntriesTest {
 
     @Test
     public void shouldRetrieveValueWhenPropertyDefined() {
-        def value = entries['aProperty'].value
+        def value = entries['aProperty'].string
 
         assertThat(value).isEqualTo('qwerty')
     }
@@ -43,7 +43,7 @@ public class FilePropertiesEntriesTest {
     @Test
     public void shouldThrowIllegalArgumentExceptionWhenTryingToAccessValueOfUndefinedProperty() {
         try {
-            entries['notThere'].value
+            entries['notThere'].string
             fail('IllegalArgumentException expected')
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage()).startsWith("No value defined for property 'notThere'")
@@ -103,11 +103,11 @@ public class FilePropertiesEntriesTest {
         def includingEntries = FilePropertiesEntries.create(new File(Resources.getResource('including.properties').toURI()))
 
         entries.keys.each { String key ->
-            assertThat(moreEntries[key].value).isEqualTo(entries[key].value)
+            assertThat(moreEntries[key].string).isEqualTo(entries[key].string)
         }
-        assertThat(moreEntries['foo'].value).isEqualTo(includingEntries['foo'].value)
-        assertThat(moreEntries['a'].value).isEqualTo('android')
-        assertThat(includingEntries['a'].value).isEqualTo('apple')
+        assertThat(moreEntries['foo'].string).isEqualTo(includingEntries['foo'].string)
+        assertThat(moreEntries['a'].string).isEqualTo('android')
+        assertThat(includingEntries['a'].string).isEqualTo('apple')
     }
 
 }

--- a/plugin/src/test/groovy/com/novoda/buildproperties/test/EntrySubject.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/test/EntrySubject.groovy
@@ -35,8 +35,8 @@ public final class EntrySubject extends Subject<EntrySubject, Entry> {
         }
     }
 
-    private Object getEntryValue() {
-        actual().value
+    private String getEntryValue() {
+        actual().string
     }
 
     public void willThrow(CompositeException compositeException) {


### PR DESCRIPTION
> Tracked in JIRA by [PT-318](https://novoda.atlassian.net/browse/PT-318)

### Scope of the PR

The plugin at the moment breaks the build when applied to a project that is not an Android one. This is actually not necessary: despite being adding some neat features in Android projects the plugin can be used on its own to list and access properties from files. This will make @frapontillo happy I hope, and will solve #3 altogether.

### Considerations/Implementation Details

- Moved code amending the Android extension to be executed only in Android projects, removed the check throwing the silly exception altogether.
- Removed the (useless?) `Entry.getValue()` from the public API, preferring always a typed accessor instead.
- Updated `README` to reflect all features provided, moving the Android-specific to a separate section.

#### Testing

Obsolete tests have been removed, as well as the dependency from the Android plugin where not needed.
