### PR TITLE
Remove project properties built-in evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,6 @@ A problem occurred while evaluating entry:
 
 ```
 
-#### Override properties at build time
-A property from any file listed in `buildProperties` can be overridden at
-build time specifying a new value as a project property (ie: `-PapiKey=newValue`).
-
 #### Properties inheritance
 It might be useful to have properties files that can recursively include
 other properties files (specified via an `include` property).

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -40,11 +40,7 @@ class BuildProperties {
     }
 
     Entry getAt(String key) {
-        if (project.hasProperty(key)) {
-            new Entry(key, { project[key] })
-        } else {
-            entries.getAt(key)
-        }
+        entries.getAt(key)
     }
 
     private static class LazyEntries extends Entries {

--- a/plugin/src/test/groovy/com/novoda/buildproperties/AndroidProjectIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/AndroidProjectIntegrationTest.groovy
@@ -68,14 +68,6 @@ public class AndroidProjectIntegrationTest {
     }
 
     @Test
-    public void shouldOverridePropertyValueInFileWithValueProvidedViaCommandLine() {
-        assertThat(PROJECT.secrets['overridable']).isNotEqualTo(COMMAND_LINE_PROPERTY)
-        [PROJECT.debugBuildConfig.text, PROJECT.releaseBuildConfig.text].each { String generatedBuildConfig ->
-            assertThat(generatedBuildConfig).contains("public static final String OVERRIDABLE = \"$COMMAND_LINE_PROPERTY\";")
-        }
-    }
-
-    @Test
     public void shouldEvaluateFallbackWhenNeeded() {
         EntrySubject.assertThat(PROJECT.secrets['FOO']).willThrow(IllegalArgumentException)
         [PROJECT.debugBuildConfig.text, PROJECT.releaseBuildConfig.text].each { String generatedBuildConfig ->
@@ -119,7 +111,7 @@ public class AndroidProjectIntegrationTest {
                     .withProjectDir(projectDir)
                     .withDebug(true)
                     .forwardStdOutput(new OutputStreamWriter(System.out))
-                    .withArguments('clean', "-Poverridable=$COMMAND_LINE_PROPERTY", 'assemble')
+                    .withArguments('clean', 'assemble')
                     .build()
             debugBuildConfig = new File(buildDir, 'generated/source/buildConfig/debug/com/novoda/buildpropertiesplugin/sample/BuildConfig.java')
             releaseBuildConfig = new File(buildDir, 'generated/source/buildConfig/release/com/novoda/buildpropertiesplugin/sample/BuildConfig.java')

--- a/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
@@ -42,16 +42,6 @@ class BuildPropertiesTest {
         assertThat(keys).containsExactlyElementsIn(Collections.list(entries.keys))
     }
 
-    @Test
-    public void shouldReturnDifferentValueFromEntriesWhenPropertyValueOverriddenInProject() {
-        project.ext.a = 'x'
-
-        def value = buildProperties['a'].string
-
-        assertThat(value).isNotEqualTo(entries['a'].string)
-        assertThat(value).isEqualTo('x')
-    }
-
     static class TestEntries extends Entries {
 
         private Map<String, ?> entries = [


### PR DESCRIPTION
> Tracked in JIRA by [PT-432](https://novoda.atlassian.net/browse/PT-432)

### Scope of the PR

We noticed that some of the properties from the properties file resulted always being `undefined`.
The problem is some of these properties defined in the file(s) can clash with properties already defined in the project, skipping further evaluation from the files.
We agreed we should remove the evaluation of project properties from the plugin and let people introduce such functionality on top of the provided facilities if needed.

### Considerations/Implementation Details

- Removed project properties evaluation in `BuildProperties.getAt(key)`
- Updated `README` to remove mention of deleted feature

#### Testing

Obsolete tests have been removed.
