### PR TITLE
Release v0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 Change Log
 ==========
 
-Version 0.2 *(14/11/2016)*
+Version 0.3 [Version 0.3](https://github.com/novoda/gradle-build-properties-plugin/releases/tag/v0.3)
+--------------------------
+
+- Removed built-in evaluation of project properties ([#PR12](https://github.com/novoda/gradle-build-properties-plugin/pull/12)).
+
+Version 0.2 [Version 0.2](https://github.com/novoda/gradle-build-properties-plugin/releases/tag/v0.2)
 --------------------------
 
 - Made plugin compatible with non-Android projects ([#PR5](https://github.com/novoda/gradle-build-properties-plugin/pull/5)).
 
-Version 0.1 *(11/11/2016)*
+Version 0.1 [Version 0.1](https://github.com/novoda/gradle-build-properties-plugin/releases/tag/v0.1)
 --------------------------
 
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.novoda:gradle-build-properties-plugin:0.2'
+    classpath 'com.novoda:gradle-build-properties-plugin:0.3'
   }
 }
 ```

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -3,6 +3,6 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'gradle-build-properties-plugin'
-    publishVersion = '0.2'
+    publishVersion = '0.3'
     website = 'https://github.com/novoda/gradle-build-properties-plugin'
 }


### PR DESCRIPTION
> Not tracked in JIRA

### Scope of the PR

We want to release a new version of the plugin on Novoda Bintray maven repo, to ship the changes from #12.

### Considerations/Implementation Details

- Updated plugin version in publishing configuration and `README` file
- Updated `CHANGELOG` to track changes in release