### PR TITLE
Use dynamic types in Android utility methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ android {
 
     defaultConfig {
         ...
-        buildConfigProperty 'FOO', buildProperties.secrets['foo'] // bar
-        buildConfigProperty 'A_KEY', buildProperties.secrets['aKey'] // overriddenPreviousValue
-        buildConfigProperty 'A_NEW_KEY', buildProperties.secrets['aNewKey'] // aNewValue
+        buildConfigString 'FOO', buildProperties.secrets['foo'] // bar
+        buildConfigString 'A_KEY', buildProperties.secrets['aKey'] // overriddenPreviousValue
+        buildConfigString 'A_NEW_KEY', buildProperties.secrets['aNewKey'] // aNewValue
         ...
     }
 }
@@ -174,11 +174,11 @@ When applying the `gradle-build-properties-plugin` to an Android project you get
 
 #### 1. Store a property value into your `BuildConfig`
 In any product flavor configuration (or `defaultConfig`) you can use
-`buildConfigProperty` as follows:
+`buildConfigString` as follows:
 ```gradle
     defaultConfig {
         ...
-        buildConfigProperty 'API_KEY', buildProperties.secrets['apiKey']
+        buildConfigString 'API_KEY', buildProperties.secrets['apiKey']
         ...
     }
 ```

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
@@ -85,26 +85,17 @@ class BuildPropertiesPlugin implements Plugin<Project> {
         }
         target.ext.resValueBoolean = { String name, def value ->
             resValue('bool', name, {
-                if (value instanceof Entry) {
-                    return value.boolean
-                }
-                return Boolean.toString(value)
+                return Boolean.toString(value instanceof Entry ? value.boolean : value)
             })
         }
         target.ext.resValueInt = { String name, def value ->
             resValue('integer', name, {
-                if (value instanceof Entry) {
-                    return value.int
-                }
-                return Integer.toString(value)
+                return Integer.toString(value instanceof Entry ? value.int : value)
             })
         }
         target.ext.resValueString = { String name, def value ->
             resValue('string', name, {
-                if (value instanceof Entry) {
-                    return "\"$value.string\""
-                }
-                return "\"$value\""
+                return "\"${value instanceof Entry ? value.string : value}\""
             })
         }
     }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
@@ -54,42 +54,27 @@ class BuildPropertiesPlugin implements Plugin<Project> {
 
         target.ext.buildConfigBoolean = { String name, def value ->
             buildConfigField('boolean', name, {
-                if (value instanceof Entry) {
-                    return value.boolean
-                }
-                return Boolean.toString(value)
+                return Boolean.toString(value instanceof Entry ? value.boolean : value)
             })
         }
         target.ext.buildConfigInt = { String name, def value ->
             buildConfigField('int', name, {
-                if (value instanceof Entry) {
-                    return value.int
-                }
-                return Integer.toString(value)
+                return Integer.toString(value instanceof Entry ? value.int : value)
             })
         }
         target.ext.buildConfigLong = { String name, def value ->
             buildConfigField('long', name, {
-                if (value instanceof Entry) {
-                    return value.long
-                }
-                return "${Long.toString(value)}L"
+                return "${Long.toString(value instanceof Entry ? value.long : value)}L"
             })
         }
         target.ext.buildConfigDouble = { String name, def value ->
             buildConfigField('double', name, {
-                if (value instanceof Entry) {
-                    return value.double
-                }
-                return Double.toString(value)
+                return Double.toString(value instanceof Entry ? value.double : value)
             })
         }
         target.ext.buildConfigString = { String name, def value ->
             buildConfigField('String', name, {
-                if (value instanceof Entry) {
-                    return "\"$value.string\""
-                }
-                return "\"$value\""
+                return "\"${value instanceof Entry ? value.string : value}\""
             })
         }
     }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
@@ -28,18 +28,18 @@ class BuildPropertiesPlugin implements Plugin<Project> {
     private static void amendAndroidExtension(Project project) {
         def android = project.extensions.findByName("android")
         android.defaultConfig.with {
-            addBuildConfigSupportTo(it, project)
-            addResValueSupportTo(it, project)
+            addBuildConfigSupportTo(it)
+            addResValueSupportTo(it)
         }
 
         android.productFlavors.all {
-            addBuildConfigSupportTo(it, project)
-            addResValueSupportTo(it, project)
+            addBuildConfigSupportTo(it)
+            addResValueSupportTo(it)
         }
 
         android.buildTypes.all {
-            addBuildConfigSupportTo(it, project)
-            addResValueSupportTo(it, project)
+            addBuildConfigSupportTo(it)
+            addResValueSupportTo(it)
         }
 
         android.signingConfigs.all {
@@ -47,50 +47,80 @@ class BuildPropertiesPlugin implements Plugin<Project> {
         }
     }
 
-    private static void addBuildConfigSupportTo(target, Project project) {
+    private static void addBuildConfigSupportTo(target) {
         def buildConfigField = { String type, String name, Closure<String> value ->
             target.buildConfigField type, name, value()
         }
 
-        target.ext.buildConfigBoolean = { String name, Boolean value ->
-            buildConfigField('boolean', name, { Boolean.toString(value) })
+        target.ext.buildConfigBoolean = { String name, def value ->
+            buildConfigField('boolean', name, {
+                if (value instanceof Entry) {
+                    return value.boolean
+                }
+                return Boolean.toString(value)
+            })
         }
-        target.ext.buildConfigInt = { String name, Integer value ->
-            buildConfigField('int', name, { Integer.toString(value) })
+        target.ext.buildConfigInt = { String name, def value ->
+            buildConfigField('int', name, {
+                if (value instanceof Entry) {
+                    return value.int
+                }
+                return Integer.toString(value)
+            })
         }
-        target.ext.buildConfigLong = { String name, Long value ->
-            buildConfigField('long', name, { "${Long.toString(value)}L" })
+        target.ext.buildConfigLong = { String name, def value ->
+            buildConfigField('long', name, {
+                if (value instanceof Entry) {
+                    return value.long
+                }
+                return "${Long.toString(value)}L"
+            })
         }
-        target.ext.buildConfigDouble = { String name, Double value ->
-            buildConfigField('double', name, { Double.toString(value) })
+        target.ext.buildConfigDouble = { String name, def value ->
+            buildConfigField('double', name, {
+                if (value instanceof Entry) {
+                    return value.double
+                }
+                return Double.toString(value)
+            })
         }
-        target.ext.buildConfigString = { String name, String value ->
-            buildConfigField('String', name, { "\"$value\"" })
-        }
-        target.ext.buildConfigProperty = { String name, Entry entry ->
-            project.afterEvaluate {
-                target.buildConfigField 'String', name, "\"${entry.string}\""
-            }
+        target.ext.buildConfigString = { String name, def value ->
+            buildConfigField('String', name, {
+                if (value instanceof Entry) {
+                    return "\"$value.string\""
+                }
+                return "\"$value\""
+            })
         }
     }
 
-    private static void addResValueSupportTo(target, Project project) {
+    private static void addResValueSupportTo(target) {
         def resValue = { String type, String name, Closure<String> value ->
             target.resValue type, name, value()
         }
-        target.ext.resValueBoolean = { String name, Boolean value ->
-            resValue('bool', name, { Boolean.toString(value) })
+        target.ext.resValueBoolean = { String name, def value ->
+            resValue('bool', name, {
+                if (value instanceof Entry) {
+                    return value.boolean
+                }
+                return Boolean.toString(value)
+            })
         }
-        target.ext.resValueInt = { String name, Integer value ->
-            resValue('integer', name, { Integer.toString(value) })
+        target.ext.resValueInt = { String name, def value ->
+            resValue('integer', name, {
+                if (value instanceof Entry) {
+                    return value.int
+                }
+                return Integer.toString(value)
+            })
         }
-        target.ext.resValueString = { String name, String value ->
-            resValue('string', name, { "\"$value\"" })
-        }
-        target.ext.resValueProperty = { String name, Entry entry ->
-            project.afterEvaluate {
-                target.resValue 'string', name, "\"${entry.string}\""
-            }
+        target.ext.resValueString = { String name, def value ->
+            resValue('string', name, {
+                if (value instanceof Entry) {
+                    return "\"$value.string\""
+                }
+                return "\"$value\""
+            })
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/buildproperties/Entry.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/Entry.groovy
@@ -22,6 +22,10 @@ class Entry {
         getValue() as Integer
     }
 
+    Long getLong() {
+        getValue() as Long
+    }
+
     Double getDouble() {
         getValue() as Double
     }

--- a/plugin/src/test/groovy/com/novoda/buildproperties/AndroidProjectIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/AndroidProjectIntegrationTest.groovy
@@ -18,7 +18,6 @@ public class AndroidProjectIntegrationTest {
 
     public static final ProjectRule PROJECT = new ProjectRule()
     public static final EnvironmentVariables ENV = new EnvironmentVariables()
-    public static final String COMMAND_LINE_PROPERTY = 'modified from command line'
     public static final String ENV_VAR_VALUE = '123456'
 
     @ClassRule

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -29,14 +29,14 @@ buildProperties {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '24.0.2'
 
     defaultConfig {
-        applicationId "com.novoda.buildpropertiesplugin.sample"
+        applicationId 'com.novoda.buildpropertiesplugin.sample'
         minSdkVersion 16
         targetSdkVersion 23
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
         buildConfigBoolean 'TEST_BOOLEAN', false
         buildConfigInt 'TEST_INT', 42
         buildConfigLong 'TEST_LONG', Long.MAX_VALUE

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -37,10 +37,10 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName '1.0'
-        buildConfigBoolean 'TEST_BOOLEAN', false
-        buildConfigInt 'TEST_INT', 42
-        buildConfigLong 'TEST_LONG', Long.MAX_VALUE
-        buildConfigDouble 'TEST_DOUBLE', Math.PI
+        buildConfigBoolean 'TEST_BOOLEAN', buildProperties.secrets['notThere'].or(false)
+        buildConfigInt 'TEST_INT', buildProperties.secrets['notThere'].or(42)
+        buildConfigLong 'TEST_LONG', buildProperties.secrets['notThere'].or(Long.MAX_VALUE)
+        buildConfigDouble 'TEST_DOUBLE', buildProperties.secrets['notThere'].or(Math.PI)
         buildConfigString 'TEST_STRING', 'whateva'
         buildConfigString 'OVERRIDABLE', buildProperties.secrets['overridable']
         buildConfigString 'GOOGLE_MAPS_KEY', buildProperties.secrets['googleMapsKey']

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -41,12 +41,12 @@ android {
         buildConfigInt 'TEST_INT', 42
         buildConfigLong 'TEST_LONG', Long.MAX_VALUE
         buildConfigDouble 'TEST_DOUBLE', Math.PI
-        buildConfigString 'TEST_STRING', "whateva"
-        buildConfigProperty 'OVERRIDABLE', buildProperties.secrets['overridable']
-        buildConfigProperty 'GOOGLE_MAPS_KEY', buildProperties.secrets['googleMapsKey']
-        buildConfigProperty 'SUPER_SECRET', buildProperties.secrets['superSecret']
-        buildConfigProperty 'FOO', buildProperties.secrets['notThere'].or(buildProperties.notThere['foo']).or('bar')
-        buildConfigProperty 'WAT', buildProperties.env['WAT'].or('?!?')
+        buildConfigString 'TEST_STRING', 'whateva'
+        buildConfigString 'OVERRIDABLE', buildProperties.secrets['overridable']
+        buildConfigString 'GOOGLE_MAPS_KEY', buildProperties.secrets['googleMapsKey']
+        buildConfigString 'SUPER_SECRET', buildProperties.secrets['superSecret']
+        buildConfigString 'FOO', buildProperties.secrets['notThere'].or(buildProperties.notThere['foo']).or('bar')
+        buildConfigString 'WAT', buildProperties.env['WAT'].or('?!?')
     }
 
     signingConfigs {
@@ -61,13 +61,13 @@ android {
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
-            buildConfigProperty 'ONLY_DEBUG', buildProperties.secrets['superSecret']
+            buildConfigString 'ONLY_DEBUG', buildProperties.secrets['superSecret']
             resValueInt 'debug_test_int', 100
             resValueBoolean 'debug_test_bool', true
             resValueString 'debug_test_string', 'dunno bro...'
-            resValueProperty 'super_secret', buildProperties.secrets['superSecret']
-            resValueProperty 'google_maps_key', buildProperties.resValues['google_maps_key']
-            resValueProperty 'another_key', buildProperties.resValues['another_key']
+            resValueString 'super_secret', buildProperties.secrets['superSecret']
+            resValueString 'google_maps_key', buildProperties.resValues['google_maps_key']
+            resValueString 'another_key', buildProperties.resValues['another_key']
         }
         release {
             minifyEnabled false

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -62,8 +62,8 @@ android {
         debug {
             signingConfig signingConfigs.debug
             buildConfigString 'ONLY_DEBUG', buildProperties.secrets['superSecret']
-            resValueInt 'debug_test_int', 100
-            resValueBoolean 'debug_test_bool', true
+            resValueInt 'debug_test_int', buildProperties.secrets['notThere'].or(100)
+            resValueBoolean 'debug_test_bool', buildProperties.secrets['notThere'].or(true)
             resValueString 'debug_test_string', 'dunno bro...'
             resValueString 'super_secret', buildProperties.secrets['superSecret']
             resValueString 'google_maps_key', buildProperties.resValues['google_maps_key']


### PR DESCRIPTION
> Addresses #17 

### Scope of the PR

At the moment if the generated field/resource needs to have a different type than `String` the only option is to use typed accessors, eg:
```
buildConfigDouble 'RATE', buildProperties.bar['rate'].or{ 1.0 }.double
```
<br/>

It would be better if all the `buildConfig*` and `resValue*` utilities exposed by the plugin worked directly with `Entry` instances, eg:
```
buildConfigDouble 'RATE' buildProperties.bar['rate'].or { 1.0 }
```

This will incidentally make obsolete `buildConfigProperty` and `resValueProperty`, which implicitly convert any value to `String`.

### Considerations/Implementation Details

All the `buildConfig*` and `resValue*` utility methods now declare inputs as Groovy dynamic types. We then inspect the type and explicitly invoke the right typed getters when an `Entry` instance is provided as parameter.
Also `buildConfigProperty` and `resValueProperty` have been removed, because users can use `buildConfigString` and `resValueString` in the same scenarios.