### PR TITLE
Remove built-in signingConfig support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@ file that is not checked in as part of your repo for security reasons
 your application `BuildConfig` or in some resource file.
 
 This plugin aims to provide a simple way to:
-- define handles to a properties file in your build script (à la `signingConfig`)
+- define handles to a properties file in your build script
 - generate fields in your `BuildConfig` with values from a properties file
 - generate resources with values from a properties file
-- load signing configurations from a properties file
 
 
 ## Adding to your project
@@ -195,21 +194,7 @@ In any product flavor configuration (or `defaultConfig`) you can use
     }
 ```
 
-#### 3. Load signing configuration from properties
-Instead of inlining your passwords and other details in your build script
-you can fill the signing configuration using a properties file.
-```gradle
-signingConfigs {
-  release {
-    signingConfigProperties buildProperties.releaseSigning
-  }
-}
-```
-The plugin will automatically retrieve all the needed fields from the
-properties file. Note: the path of the keystore file is considered relative
-to the path of the specified properties file.
-
-#### 4. Typed `buildConfigField` / `resValue`
+#### 3. Typed `buildConfigField` / `resValue`
 The plugin enhances the `buildConfigField` and `resValue` facilities to
 enforce types. To generate a string field in your `BuildConfig` you used to write:
 ```gradle

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -31,10 +31,6 @@ class BuildProperties {
         this.entries = entries
     }
 
-    File getParentFile() {
-        entries.parentFile
-    }
-
     Enumeration<String> getKeys() {
         entries.keys
     }
@@ -70,15 +66,8 @@ class BuildProperties {
         }
 
         @Override
-        File getParentFile() {
-            entries.getParentFile()
-        }
-
-        @Override
         Enumeration<String> getKeys() {
             entries.getKeys()
         }
-
     }
-
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
@@ -14,7 +14,7 @@ class BuildPropertiesPlugin implements Plugin<Project> {
                 return new BuildProperties(name, project)
             }
         })
-        container.create('env').entries(new EnvironmentPropertiesEntries(project))
+        container.create('env').entries(new EnvironmentPropertiesEntries())
         project.extensions.add('buildProperties', container)
 
         project.plugins.withId('com.android.application') {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
@@ -41,10 +41,6 @@ class BuildPropertiesPlugin implements Plugin<Project> {
             addBuildConfigSupportTo(it)
             addResValueSupportTo(it)
         }
-
-        android.signingConfigs.all {
-            addSigningConfigSupportTo(it)
-        }
     }
 
     private static void addBuildConfigSupportTo(target) {
@@ -99,14 +95,4 @@ class BuildPropertiesPlugin implements Plugin<Project> {
             })
         }
     }
-
-    private static void addSigningConfigSupportTo(target) {
-        target.ext.signingConfigProperties = { BuildProperties buildProperties ->
-            target.storeFile new File(buildProperties.parentFile, buildProperties['storeFile'].string)
-            target.storePassword buildProperties['storePassword'].string
-            target.keyAlias buildProperties['keyAlias'].string
-            target.keyPassword buildProperties['keyPassword'].string
-        }
-    }
-
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/Entries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/Entries.groovy
@@ -12,8 +12,5 @@ abstract class Entries {
         })
     }
 
-    abstract File getParentFile()
-
     abstract Enumeration<String> getKeys()
-
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/EnvironmentPropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/EnvironmentPropertiesEntries.groovy
@@ -1,14 +1,6 @@
 package com.novoda.buildproperties
 
-import org.gradle.api.Project
-
 class EnvironmentPropertiesEntries extends Entries {
-
-    private final Project project
-
-    EnvironmentPropertiesEntries(Project project) {
-        this.project = project
-    }
 
     @Override
     boolean contains(String key) {
@@ -22,11 +14,6 @@ class EnvironmentPropertiesEntries extends Entries {
             return envValue
         }
         throw new IllegalArgumentException("No environment variable defined for key '$key'")
-    }
-
-    @Override
-    File getParentFile() {
-        project.rootDir
     }
 
     @Override

--- a/plugin/src/main/groovy/com/novoda/buildproperties/FilePropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/FilePropertiesEntries.groovy
@@ -49,11 +49,6 @@ class FilePropertiesEntries extends Entries {
     }
 
     @Override
-    File getParentFile() {
-        file.parentFile
-    }
-
-    @Override
     Enumeration<String> getKeys() {
         Collections.enumeration(keys)
     }

--- a/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
@@ -61,11 +61,6 @@ class BuildPropertiesTest {
         }
 
         @Override
-        File getParentFile() {
-            throw new UnsupportedOperationException()
-        }
-
-        @Override
         Enumeration<String> getKeys() {
             Collections.enumeration(entries.keySet())
         }

--- a/plugin/src/test/groovy/com/novoda/buildproperties/EnvironmentPropertiesEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/EnvironmentPropertiesEntriesTest.groovy
@@ -27,7 +27,7 @@ class EnvironmentPropertiesEntriesTest {
         project = ProjectBuilder.builder()
                 .withProjectDir(temp.newFolder())
                 .build()
-        entries = new EnvironmentPropertiesEntries(project)
+        entries = new EnvironmentPropertiesEntries()
     }
 
     @Test
@@ -67,12 +67,4 @@ class EnvironmentPropertiesEntriesTest {
 
         assertThat(Collections.list(keys)).containsAllOf('FOO', 'BAR')
     }
-
-    @Test
-    public void shouldProvideProjectRootDirAsParentFile() {
-        File parentFile = entries.parentFile
-
-        assertThat(parentFile).isEqualTo(project.rootDir)
-    }
-
 }

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -49,12 +49,21 @@ android {
         buildConfigString 'WAT', buildProperties.env['WAT'].or('?!?')
     }
 
+    signingConfigs.all { signingConfig ->
+        signingConfig.ext.from = { buildProperties ->
+            signingConfig.storeFile rootProject.file("properties/${buildProperties['storeFile'].string}")
+            signingConfig.storePassword buildProperties['storePassword'].string
+            signingConfig.keyAlias buildProperties['keyAlias'].string
+            signingConfig.keyPassword buildProperties['keyPassword'].string
+        }
+    }
+
     signingConfigs {
         debug {
-            signingConfigProperties buildProperties.debugSigning
+            from buildProperties.debugSigning
         }
         release {
-            signingConfigProperties buildProperties.releaseSigning
+            from buildProperties.releaseSigning
         }
     }
 


### PR DESCRIPTION
> Addresses #22 

### Scope of the PR
The support of Android signing config via the built-in `signingConfigProperties` extension method is not flexible enough. While using it the user will loose the flexibility of manipulating `Entry` directly, like fallback support for instance. Also the need of resolving the keystore path forced the definition of `BuildProperties#getParentFile()`, which - in hindsight - was a bad attempt at making the resolution of the file somewhat configurable, but still bound uniquely to the implementation of `Entries` at hand.

### Considerations/Implementation Details
Removed `signingConfigProperties`, along with `BuildProperties#getParentFile()`. The sample app now shows how simple is to create a little utility method that can fill a signing config from a `BuildProperties` instance.
