### PR TITLE
Internalise lazy loading of properties files

### DIFF
--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -18,7 +18,7 @@ class BuildProperties {
     }
 
     void file(File file, String errorMessage = null) {
-        entries(FilePropertiesEntries.create(name, file, errorMessage))
+        entries(FilePropertiesEntries.create(name ?: file.name, file, errorMessage))
     }
 
     void entries(Entries entries) {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -1,7 +1,5 @@
 package com.novoda.buildproperties
 
-import org.gradle.api.GradleException
-
 class BuildProperties {
 
     private final String name
@@ -20,12 +18,7 @@ class BuildProperties {
     }
 
     void file(File file, String errorMessage = null) {
-        entries(LazyEntries.from {
-            if (!file.exists()) {
-                throw new GradleException("File $file.name does not exist.${errorMessage ? "\n$errorMessage" : ''}")
-            }
-            FilePropertiesEntries.create(name, file)
-        })
+        entries(FilePropertiesEntries.create(name, file, errorMessage))
     }
 
     void entries(Entries entries) {
@@ -38,37 +31,5 @@ class BuildProperties {
 
     Entry getAt(String key) {
         entries.getAt(key)
-    }
-
-    private static class LazyEntries extends Entries {
-
-        private final Closure<Entries> entriesProvider
-
-        static LazyEntries from(Closure<Entries> entriesProvider) {
-            new LazyEntries(entriesProvider)
-        }
-
-        private LazyEntries(Closure<Entries> entriesProvider) {
-            this.entriesProvider = entriesProvider.memoize()
-        }
-
-        private Entries getEntries() {
-            entriesProvider.call()
-        }
-
-        @Override
-        boolean contains(String key) {
-            entries.contains(key)
-        }
-
-        @Override
-        protected Object getValueAt(String key) {
-            entries.getValueAt(key)
-        }
-
-        @Override
-        Enumeration<String> getKeys() {
-            entries.getKeys()
-        }
     }
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/FilePropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/FilePropertiesEntries.groovy
@@ -7,8 +7,8 @@ class FilePropertiesEntries extends Entries {
     private final String name
     private final Closure<PropertiesProvider> providerClosure
 
-    static FilePropertiesEntries create(String name = null, File file, String errorMessage = null) {
-        new FilePropertiesEntries(name ?: file.name, {
+    static FilePropertiesEntries create(String name, File file, String errorMessage = null) {
+        new FilePropertiesEntries(name, {
             if (!file.exists()) {
                 throw new GradleException("File $file.name does not exist.${errorMessage ? "\n$errorMessage" : ''}")
             }

--- a/plugin/src/test/groovy/com/novoda/buildproperties/AndroidProjectIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/AndroidProjectIntegrationTest.groovy
@@ -125,7 +125,7 @@ class AndroidProjectIntegrationTest {
             releaseBuildConfig = new File(buildDir, 'generated/source/buildConfig/release/com/novoda/buildpropertiesplugin/sample/BuildConfig.java')
             debugResValues = new File(buildDir, 'generated/res/resValues/debug/values/generated.xml')
             releaseResValues = new File(buildDir, 'generated/res/resValues/release/values/generated.xml')
-            secrets = FilePropertiesEntries.create(new File(projectDir, 'properties/secrets.properties'))
+            secrets = FilePropertiesEntries.create('secrets', new File(projectDir, 'properties/secrets.properties'))
             return base;
         }
     }


### PR DESCRIPTION
### Scope of the PR
Removes `LazyEntries` and move lazy-loading logic inside `FilePropertiesEntries` (where it's actually needed).

### Considerations/Implementation Details
While working on one of the new features I realised that `LazyEntries` is used as wrapper around `FilePropertiesEntries` only, and it would make difficult the delegation of getters and other utility methods that would not require the access to the properties file itself. For this reason I decided to internalise the lazy-lading as part of the `FilePropertiesEntries` implementation.