### PR TITLE
Rearrange packages for internal API 

### DIFF
--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -1,5 +1,8 @@
 package com.novoda.buildproperties
 
+import com.novoda.buildproperties.internal.FilePropertiesEntries
+import com.novoda.buildproperties.internal.MapEntries
+
 class BuildProperties {
 
     private final String name

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
@@ -1,5 +1,6 @@
-package com.novoda.buildproperties
+package com.novoda.buildproperties.internal
 
+import com.novoda.buildproperties.Entries
 import org.gradle.api.GradleException
 
 class FilePropertiesEntries extends Entries {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
@@ -1,4 +1,6 @@
-package com.novoda.buildproperties
+package com.novoda.buildproperties.internal
+
+import com.novoda.buildproperties.Entries
 
 class MapEntries extends Entries {
     private final Map<String, Object> map

--- a/plugin/src/test/groovy/com/novoda/buildproperties/AndroidProjectIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/AndroidProjectIntegrationTest.groovy
@@ -1,6 +1,7 @@
 package com.novoda.buildproperties
 
 import com.google.common.io.Resources
+import com.novoda.buildproperties.internal.FilePropertiesEntries
 import com.novoda.buildproperties.test.EntrySubject
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.internal.DefaultGradleRunner

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
@@ -1,13 +1,12 @@
-package com.novoda.buildproperties
+package com.novoda.buildproperties.internal
 
 import com.google.common.io.Resources
+import com.novoda.buildproperties.Entry
+import com.novoda.buildproperties.internal.FilePropertiesEntries
 import org.gradle.api.GradleException
 import org.junit.Before
 import org.junit.Test
 
-import static com.google.common.truth.Truth.assertThat
-import static com.novoda.buildproperties.test.ExtendedTruth.assertThat
-import static com.novoda.buildproperties.test.ExtendedTruth.assertThat
 import static com.novoda.buildproperties.test.ExtendedTruth.assertThat
 import static org.junit.Assert.fail
 

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/MapEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/MapEntriesTest.groovy
@@ -1,5 +1,7 @@
-package com.novoda.buildproperties
+package com.novoda.buildproperties.internal
 
+import com.novoda.buildproperties.Entry
+import com.novoda.buildproperties.internal.MapEntries
 import org.junit.Test
 
 import static com.novoda.buildproperties.test.ExtendedTruth.assertThat


### PR DESCRIPTION
### Scope of the PR
Introduces `com.novoda.buildproperties.internal` package.

### Considerations/Implementation Details
Going forward it would be useful to highlight what's to be susceptible to change in the future and what is not. This first step in that direction is to define a package to collect implementations of `Entries` that are considered internal API. This should help to discourage consumers of the plugin to use those classes directly.