### PR TITLE
Rename public API to create build properties set

### DIFF
--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -23,11 +23,11 @@ class BuildProperties {
         name
     }
 
-    void from(Map<String, Object> map) {
+    void using(Map<String, Object> map) {
         entries(new MapEntries(map, exceptionFactory, additionalMessageProvider))
     }
 
-    void from(File file) {
+    void using(File file) {
         entries(FilePropertiesEntries.create(name ?: file.name, file, exceptionFactory, additionalMessageProvider))
     }
 

--- a/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
@@ -34,7 +34,7 @@ class BuildPropertiesTest {
     void shouldReturnMapValuesWhenEntriesFromMap() {
         project.buildProperties {
             map {
-                from([a: 'value_a', b: 'value_b', c: 'value_c'])
+                using([a: 'value_a', b: 'value_b', c: 'value_c'])
             }
         }
 
@@ -51,7 +51,7 @@ class BuildPropertiesTest {
 
         project.buildProperties {
             env {
-                from System.getenv()
+                using System.getenv()
             }
         }
 
@@ -68,7 +68,7 @@ class BuildPropertiesTest {
 
         project.buildProperties {
             prj {
-                from project.properties
+                using project.properties
             }
         }
 
@@ -81,7 +81,7 @@ class BuildPropertiesTest {
     void shouldNotThrowExceptionWhenEntriesFromNonExistentPropertiesFile() {
         project.buildProperties {
             foo {
-                from project.file('foo.properties')
+                using project.file('foo.properties')
             }
         }
     }
@@ -90,7 +90,7 @@ class BuildPropertiesTest {
     void shouldThrowWhenAccessingPropertyFromNonExistentPropertiesFile() {
         project.buildProperties {
             foo {
-                from project.file('foo.properties')
+                using project.file('foo.properties')
             }
         }
 
@@ -110,7 +110,7 @@ class BuildPropertiesTest {
         try {
             project.buildProperties {
                 foo {
-                    from project.file('foo.properties')
+                    using project.file('foo.properties')
                     setDescription(description)
                 }
             }
@@ -131,7 +131,7 @@ class BuildPropertiesTest {
 
         project.buildProperties {
             test {
-                from propertiesFile
+                using propertiesFile
             }
         }
 

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -9,27 +9,27 @@ apply plugin: com.novoda.buildproperties.BuildPropertiesPlugin
 
 buildProperties {
     notThere {
-        from rootProject.file('whatever')
+        using rootProject.file('whatever')
         description =   'This file actually doesn\'t exist. This properties set is used to show how\n' +
                         'properties files are lazy loaded.'
     }
     secrets {
-        from rootProject.file('properties/secrets.properties')
+        using rootProject.file('properties/secrets.properties')
     }
     resValues {
-        from rootProject.file('properties/resValues.properties')
+        using rootProject.file('properties/resValues.properties')
     }
     debugSigning {
-        from rootProject.file('properties/debugSigning.properties')
+        using rootProject.file('properties/debugSigning.properties')
     }
     releaseSigning {
-        from rootProject.file('properties/releaseSigning.properties')
+        using rootProject.file('properties/releaseSigning.properties')
     }
     env {
-        from System.getenv()
+        using System.getenv()
     }
     cli {
-        from project.properties
+        using project.properties
     }
 }
 


### PR DESCRIPTION
Following the suggestion from @blundell I decided to rename the public API to create a build properties set: `BuildProperties.from()` introduced in the unreleased version of the plugin (#25 and #32) has been replaced by `BuildProperties.using()`.