### PR TITLE
Remove provider dependency

### DIFF
--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -1,8 +1,6 @@
 package com.novoda.buildproperties
 
-import com.novoda.buildproperties.internal.AdditionalMessageProvider
 import com.novoda.buildproperties.internal.DefaultExceptionFactory
-import com.novoda.buildproperties.internal.ExceptionFactory
 import com.novoda.buildproperties.internal.FilePropertiesEntries
 import com.novoda.buildproperties.internal.MapEntries
 
@@ -10,13 +8,11 @@ class BuildProperties {
 
     private final String name
     private final DefaultExceptionFactory exceptionFactory
-    private final AdditionalMessageProvider additionalMessageProvider
     private Entries entries
 
     BuildProperties(String name) {
         this.name = name
         this.exceptionFactory = new DefaultExceptionFactory(name)
-        this.additionalMessageProvider = new AdditionalMessageProvider()
     }
 
     String getName() {
@@ -24,11 +20,11 @@ class BuildProperties {
     }
 
     void using(Map<String, Object> map) {
-        entries(new MapEntries(map, exceptionFactory, additionalMessageProvider))
+        entries(new MapEntries(map, exceptionFactory))
     }
 
     void using(File file) {
-        entries(FilePropertiesEntries.create(name ?: file.name, file, exceptionFactory, additionalMessageProvider))
+        entries(FilePropertiesEntries.create(name ?: file.name, file, exceptionFactory))
     }
 
     void entries(Entries entries) {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -9,7 +9,7 @@ import com.novoda.buildproperties.internal.MapEntries
 class BuildProperties {
 
     private final String name
-    private final ExceptionFactory exceptionFactory
+    private final DefaultExceptionFactory exceptionFactory
     private final AdditionalMessageProvider additionalMessageProvider
     private Entries entries
 
@@ -44,6 +44,6 @@ class BuildProperties {
     }
 
     void setDescription(String description) {
-        additionalMessageProvider.setAdditionalMessage(description)
+        exceptionFactory.additionalMessage = description
     }
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/Entries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/Entries.groovy
@@ -1,13 +1,8 @@
 package com.novoda.buildproperties
 
-import javax.inject.Provider
-
 abstract class Entries {
 
-    private final Provider<String> additionalMessageProvider
-
-    Entries(Provider<String> additionalMessageProvider) {
-        this.additionalMessageProvider = additionalMessageProvider
+    Entries() {
     }
 
     abstract boolean contains(String key)
@@ -21,8 +16,4 @@ abstract class Entries {
     }
 
     abstract Enumeration<String> getKeys()
-
-    final String getAdditionalMessage() {
-        additionalMessageProvider.get()
-    }
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/Entries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/Entries.groovy
@@ -12,11 +12,11 @@ abstract class Entries {
 
     abstract boolean contains(String key)
 
-    protected abstract Object getValueAt(String key, String additionalMessage)
+    protected abstract Object getValueAt(String key)
 
     Entry getAt(String key) {
         new Entry(key, {
-            getValueAt(key, additionalMessage)
+            getValueAt(key)
         })
     }
 

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultExceptionFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultExceptionFactory.groovy
@@ -1,6 +1,6 @@
 package com.novoda.buildproperties.internal
 
-class DefaultExceptionFactory implements ExceptionFactory {
+class DefaultExceptionFactory extends AdditionalMessageProvider implements ExceptionFactory {
 
     private final String propertiesSetName
     private final ConsoleRenderer consoleRenderer

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultExceptionFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultExceptionFactory.groovy
@@ -13,13 +13,13 @@ class DefaultExceptionFactory extends AdditionalMessageProvider implements Excep
     @Override
     Exception fileNotFound(File file) {
         String message = "Unable to create properties set 'buildProperties.$propertiesSetName': ${consoleRenderer.asClickableFileUrl(file)} does not exist."
-        BuildPropertiesException.from(message, format(getAdditionalMessage()))
+        BuildPropertiesException.from(message, format(additionalMessage))
     }
 
     @Override
     Exception propertyNotFound(String key) {
         String message = "Unable to find value for key '$key' in properties set 'buildProperties.$propertiesSetName'."
-        BuildPropertiesException.from(message, format(getAdditionalMessage()))
+        BuildPropertiesException.from(message, format(additionalMessage))
     }
 
     private String format(String additionalMessage) {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultExceptionFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultExceptionFactory.groovy
@@ -11,13 +11,13 @@ class DefaultExceptionFactory extends AdditionalMessageProvider implements Excep
     }
 
     @Override
-    Exception fileNotFound(File file, String additionalMessage) {
+    Exception fileNotFound(File file) {
         String message = "Unable to create properties set 'buildProperties.$propertiesSetName': ${consoleRenderer.asClickableFileUrl(file)} does not exist."
         BuildPropertiesException.from(message, format(getAdditionalMessage()))
     }
 
     @Override
-    Exception propertyNotFound(String key, String additionalMessage) {
+    Exception propertyNotFound(String key) {
         String message = "Unable to find value for key '$key' in properties set 'buildProperties.$propertiesSetName'."
         BuildPropertiesException.from(message, format(getAdditionalMessage()))
     }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultExceptionFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultExceptionFactory.groovy
@@ -12,12 +12,14 @@ class DefaultExceptionFactory extends AdditionalMessageProvider implements Excep
 
     @Override
     Exception fileNotFound(File file, String additionalMessage) {
-        BuildPropertiesException.from("Unable to create properties set 'buildProperties.$propertiesSetName': ${consoleRenderer.asClickableFileUrl(file)} does not exist.", format(additionalMessage))
+        String message = "Unable to create properties set 'buildProperties.$propertiesSetName': ${consoleRenderer.asClickableFileUrl(file)} does not exist."
+        BuildPropertiesException.from(message, format(getAdditionalMessage()))
     }
 
     @Override
     Exception propertyNotFound(String key, String additionalMessage) {
-        BuildPropertiesException.from("Unable to find value for key '$key' in properties set 'buildProperties.$propertiesSetName'.", format(additionalMessage))
+        String message = "Unable to find value for key '$key' in properties set 'buildProperties.$propertiesSetName'."
+        BuildPropertiesException.from(message, format(getAdditionalMessage()))
     }
 
     private String format(String additionalMessage) {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/ExceptionFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/ExceptionFactory.groovy
@@ -2,7 +2,7 @@ package com.novoda.buildproperties.internal
 
 interface ExceptionFactory {
 
-    Exception fileNotFound(File file, String additionalMessage)
+    Exception fileNotFound(File file)
 
-    Exception propertyNotFound(String key, String additionalMessage)
+    Exception propertyNotFound(String key)
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
@@ -9,18 +9,17 @@ class FilePropertiesEntries extends Entries {
 
     static FilePropertiesEntries create(String name,
                                         File file,
-                                        ExceptionFactory exceptionFactory,
-                                        AdditionalMessageProvider additionalMessageProvider) {
+                                        ExceptionFactory exceptionFactory) {
         new FilePropertiesEntries(name, {
             if (!file.exists()) {
                 throw exceptionFactory.fileNotFound(file)
             }
             PropertiesProvider.create(file, exceptionFactory)
-        }, additionalMessageProvider)
+        })
     }
 
-    private FilePropertiesEntries(String name, Closure<PropertiesProvider> providerClosure, AdditionalMessageProvider additionalMessageProvider) {
-        super(additionalMessageProvider)
+    private FilePropertiesEntries(String name, Closure<PropertiesProvider> providerClosure) {
+        super()
         this.name = name
         this.providerClosure = providerClosure.memoize()
     }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
@@ -15,7 +15,7 @@ class FilePropertiesEntries extends Entries {
             if (!file.exists()) {
                 throw exceptionFactory.fileNotFound(file)
             }
-            PropertiesProvider.create(file, exceptionFactory, additionalMessageProvider)
+            PropertiesProvider.create(file, exceptionFactory)
         }, additionalMessageProvider)
     }
 
@@ -35,8 +35,8 @@ class FilePropertiesEntries extends Entries {
     }
 
     @Override
-    protected Object getValueAt(String key, String additionalMessage) {
-        provider.getValueAt(key, additionalMessage)
+    protected Object getValueAt(String key) {
+        provider.getValueAt(key)
     }
 
     @Override
@@ -52,14 +52,14 @@ class FilePropertiesEntries extends Entries {
         final ExceptionFactory exceptionFactory
         final Set<String> keys
 
-        static PropertiesProvider create(File file, ExceptionFactory exceptionFactory, AdditionalMessageProvider additionalMessageProvider) {
+        static PropertiesProvider create(File file, ExceptionFactory exceptionFactory) {
             Properties properties = new Properties()
             properties.load(new FileInputStream(file))
 
             PropertiesProvider defaults = null
             String include = properties['include']
             if (include != null) {
-                defaults = create(new File(file.parentFile, include), exceptionFactory, additionalMessageProvider)
+                defaults = create(new File(file.parentFile, include), exceptionFactory)
             }
             new PropertiesProvider(file, properties, defaults, exceptionFactory)
         }
@@ -82,13 +82,13 @@ class FilePropertiesEntries extends Entries {
             properties[key] != null || defaults?.contains(key)
         }
 
-        Object getValueAt(String key, String additionalMessage) {
+        Object getValueAt(String key) {
             Object value = properties[key]
             if (value != null) {
                 return value
             }
             if (defaults?.contains(key)) {
-                return defaults.getValueAt(key, additionalMessage)
+                return defaults.getValueAt(key)
             }
             throw exceptionFactory.propertyNotFound(key)
         }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
@@ -13,7 +13,7 @@ class FilePropertiesEntries extends Entries {
                                         AdditionalMessageProvider additionalMessageProvider) {
         new FilePropertiesEntries(name, {
             if (!file.exists()) {
-                throw exceptionFactory.fileNotFound(file, additionalMessageProvider.additionalMessage)
+                throw exceptionFactory.fileNotFound(file)
             }
             PropertiesProvider.create(file, exceptionFactory, additionalMessageProvider)
         }, additionalMessageProvider)
@@ -90,7 +90,7 @@ class FilePropertiesEntries extends Entries {
             if (defaults?.contains(key)) {
                 return defaults.getValueAt(key, additionalMessage)
             }
-            throw exceptionFactory.propertyNotFound(key, additionalMessage)
+            throw exceptionFactory.propertyNotFound(key)
         }
 
         Enumeration<String> getKeys() {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
@@ -2,16 +2,13 @@ package com.novoda.buildproperties.internal
 
 import com.novoda.buildproperties.Entries
 
-import javax.inject.Provider
-
 class MapEntries extends Entries {
     private final Map<String, Object> map
     private final ExceptionFactory exceptionFactory
 
     MapEntries(Map<String, Object> map,
-               ExceptionFactory exceptionFactory,
-               Provider<String> additionalMessageProvider) {
-        super(additionalMessageProvider)
+               ExceptionFactory exceptionFactory) {
+        super()
         this.exceptionFactory = exceptionFactory
         this.map = Collections.unmodifiableMap(map)
     }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
@@ -22,7 +22,7 @@ class MapEntries extends Entries {
     }
 
     @Override
-    protected Object getValueAt(String key, String additionalMessage) {
+    protected Object getValueAt(String key) {
         Object value = map.get(key)
         if (value != null) {
             return value

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
@@ -27,7 +27,7 @@ class MapEntries extends Entries {
         if (value != null) {
             return value
         }
-        throw exceptionFactory.propertyNotFound(key, additionalMessage)
+        throw exceptionFactory.propertyNotFound(key)
     }
 
     @Override

--- a/plugin/src/test/groovy/com/novoda/buildproperties/AndroidProjectIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/AndroidProjectIntegrationTest.groovy
@@ -131,7 +131,7 @@ class AndroidProjectIntegrationTest {
                     new File(projectDir, 'properties/secrets.properties'),
                     new DefaultExceptionFactory('secrets')
             )
-            return base;
+            return base
         }
     }
 

--- a/plugin/src/test/groovy/com/novoda/buildproperties/AndroidProjectIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/AndroidProjectIntegrationTest.groovy
@@ -1,7 +1,6 @@
 package com.novoda.buildproperties
 
 import com.google.common.io.Resources
-import com.novoda.buildproperties.internal.AdditionalMessageProvider
 import com.novoda.buildproperties.internal.DefaultExceptionFactory
 import com.novoda.buildproperties.internal.FilePropertiesEntries
 import com.novoda.buildproperties.test.EntrySubject
@@ -130,8 +129,8 @@ class AndroidProjectIntegrationTest {
             releaseResValues = new File(buildDir, 'generated/res/resValues/release/values/generated.xml')
             secrets = FilePropertiesEntries.create('secrets',
                     new File(projectDir, 'properties/secrets.properties'),
-                    new DefaultExceptionFactory('secrets'),
-                    new AdditionalMessageProvider())
+                    new DefaultExceptionFactory('secrets')
+            )
             return base;
         }
     }

--- a/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
@@ -1,6 +1,5 @@
 package com.novoda.buildproperties
 
-import com.novoda.buildproperties.internal.ConsoleRenderer
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Before

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
@@ -21,7 +21,7 @@ class FilePropertiesEntriesTest {
     void setUp() {
         additionalMessageProvider = new AdditionalMessageProvider()
         exceptionFactory = new DefaultExceptionFactory('foo')
-        entries = FilePropertiesEntries.create('any', PROPERTIES_FILE, exceptionFactory, additionalMessageProvider)
+        entries = FilePropertiesEntries.create('any', PROPERTIES_FILE, exceptionFactory)
     }
 
     @Test
@@ -105,8 +105,8 @@ class FilePropertiesEntriesTest {
 
     @Test
     void shouldRecursivelyIncludePropertiesFromSpecifiedFilesWhenIncludeProvided() {
-        def moreEntries = FilePropertiesEntries.create('more', new File(Resources.getResource('more.properties').toURI()), exceptionFactory, additionalMessageProvider)
-        def includingEntries = FilePropertiesEntries.create('including', new File(Resources.getResource('including.properties').toURI()), exceptionFactory, additionalMessageProvider)
+        def moreEntries = FilePropertiesEntries.create('more', new File(Resources.getResource('more.properties').toURI()), exceptionFactory)
+        def includingEntries = FilePropertiesEntries.create('including', new File(Resources.getResource('including.properties').toURI()), exceptionFactory)
 
         entries.keys.each { String key ->
             assertThat(moreEntries[key].string).isEqualTo(entries[key].string)
@@ -118,7 +118,7 @@ class FilePropertiesEntriesTest {
 
     @Test
     void shouldThrowExceptionWhenAccessingPropertyFromNonExistentPropertiesFile() {
-        entries = FilePropertiesEntries.create('notThere', new File('notThere.properties'), exceptionFactory, additionalMessageProvider)
+        entries = FilePropertiesEntries.create('notThere', new File('notThere.properties'), exceptionFactory)
 
         try {
             entries['any'].string
@@ -133,7 +133,7 @@ class FilePropertiesEntriesTest {
         def additionalMessage = 'This file should contain the following properties:\n- foo\n- bar'
         def consoleRenderer = new ConsoleRenderer()
         exceptionFactory.additionalMessage = additionalMessage
-        entries = FilePropertiesEntries.create('notThere', new File('notThere.properties'), exceptionFactory, additionalMessageProvider)
+        entries = FilePropertiesEntries.create('notThere', new File('notThere.properties'), exceptionFactory)
 
         try {
             entries['any'].string

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
@@ -12,7 +12,7 @@ class FilePropertiesEntriesTest {
 
     private static final File PROPERTIES_FILE = new File(Resources.getResource('any.properties').toURI())
 
-    private ExceptionFactory exceptionFactory
+    private DefaultExceptionFactory exceptionFactory
     private AdditionalMessageProvider additionalMessageProvider
     
     private FilePropertiesEntries entries
@@ -132,7 +132,7 @@ class FilePropertiesEntriesTest {
     void shouldProvideSpecifiedErrorMessageWhenAccessingPropertyFromNonExistentPropertiesFile() {
         def additionalMessage = 'This file should contain the following properties:\n- foo\n- bar'
         def consoleRenderer = new ConsoleRenderer()
-        additionalMessageProvider.additionalMessage = additionalMessage
+        exceptionFactory.additionalMessage = additionalMessage
         entries = FilePropertiesEntries.create('notThere', new File('notThere.properties'), exceptionFactory, additionalMessageProvider)
 
         try {

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/MapEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/MapEntriesTest.groovy
@@ -49,6 +49,6 @@ class MapEntriesTest {
     }
 
     private static MapEntries givenMapEntries(Map<String, Object> properties) {
-        new MapEntries(properties, new DefaultExceptionFactory('foo'), new AdditionalMessageProvider())
+        new MapEntries(properties, new DefaultExceptionFactory('foo'))
     }
 }


### PR DESCRIPTION
### Scope of the PR
We want to tidy up the internal API of `Entries` and avoid to leak the knowledge of additional message that is only relevant to the component creating the exceptions on evaluation failure.

### Considerations/Implementation Details
The public API of `ExceptionFactory` and the internal API of `Entries` is now oblivious of the additional message, that becomes an implementation detail of `DefaultExceptionFactory`.