### PR TITLE
Remove name property from FilePropertiesEntries

### DIFF
--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -24,7 +24,7 @@ class BuildProperties {
     }
 
     void using(File file) {
-        entries(FilePropertiesEntries.create(name ?: file.name, file, exceptionFactory))
+        entries(FilePropertiesEntries.create(file, exceptionFactory))
     }
 
     void entries(Entries entries) {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -1,13 +1,14 @@
 package com.novoda.buildproperties
 
 import com.novoda.buildproperties.internal.DefaultExceptionFactory
+import com.novoda.buildproperties.internal.ExceptionFactory
 import com.novoda.buildproperties.internal.FilePropertiesEntries
 import com.novoda.buildproperties.internal.MapEntries
 
 class BuildProperties {
 
     private final String name
-    private final DefaultExceptionFactory exceptionFactory
+    private final ExceptionFactory exceptionFactory
     private Entries entries
 
     BuildProperties(String name) {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
@@ -4,13 +4,11 @@ import com.novoda.buildproperties.Entries
 
 class FilePropertiesEntries extends Entries {
 
-    private final String name
     private final Closure<PropertiesProvider> providerClosure
 
-    static FilePropertiesEntries create(String name,
-                                        File file,
+    static FilePropertiesEntries create(File file,
                                         ExceptionFactory exceptionFactory) {
-        new FilePropertiesEntries(name, {
+        new FilePropertiesEntries({
             if (!file.exists()) {
                 throw exceptionFactory.fileNotFound(file)
             }
@@ -18,9 +16,8 @@ class FilePropertiesEntries extends Entries {
         })
     }
 
-    private FilePropertiesEntries(String name, Closure<PropertiesProvider> providerClosure) {
+    private FilePropertiesEntries(Closure<PropertiesProvider> providerClosure) {
         super()
-        this.name = name
         this.providerClosure = providerClosure.memoize()
     }
 

--- a/plugin/src/test/groovy/com/novoda/buildproperties/AndroidProjectIntegrationTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/AndroidProjectIntegrationTest.groovy
@@ -127,7 +127,7 @@ class AndroidProjectIntegrationTest {
             releaseBuildConfig = new File(buildDir, 'generated/source/buildConfig/release/com/novoda/buildpropertiesplugin/sample/BuildConfig.java')
             debugResValues = new File(buildDir, 'generated/res/resValues/debug/values/generated.xml')
             releaseResValues = new File(buildDir, 'generated/res/resValues/release/values/generated.xml')
-            secrets = FilePropertiesEntries.create('secrets',
+            secrets = FilePropertiesEntries.create(
                     new File(projectDir, 'properties/secrets.properties'),
                     new DefaultExceptionFactory('secrets')
             )

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
@@ -21,7 +21,7 @@ class FilePropertiesEntriesTest {
     void setUp() {
         additionalMessageProvider = new AdditionalMessageProvider()
         exceptionFactory = new DefaultExceptionFactory('foo')
-        entries = FilePropertiesEntries.create('any', PROPERTIES_FILE, exceptionFactory)
+        entries = FilePropertiesEntries.create(PROPERTIES_FILE, exceptionFactory)
     }
 
     @Test
@@ -105,8 +105,8 @@ class FilePropertiesEntriesTest {
 
     @Test
     void shouldRecursivelyIncludePropertiesFromSpecifiedFilesWhenIncludeProvided() {
-        def moreEntries = FilePropertiesEntries.create('more', new File(Resources.getResource('more.properties').toURI()), exceptionFactory)
-        def includingEntries = FilePropertiesEntries.create('including', new File(Resources.getResource('including.properties').toURI()), exceptionFactory)
+        def moreEntries = FilePropertiesEntries.create(new File(Resources.getResource('more.properties').toURI()), exceptionFactory)
+        def includingEntries = FilePropertiesEntries.create(new File(Resources.getResource('including.properties').toURI()), exceptionFactory)
 
         entries.keys.each { String key ->
             assertThat(moreEntries[key].string).isEqualTo(entries[key].string)
@@ -118,7 +118,7 @@ class FilePropertiesEntriesTest {
 
     @Test
     void shouldThrowExceptionWhenAccessingPropertyFromNonExistentPropertiesFile() {
-        entries = FilePropertiesEntries.create('notThere', new File('notThere.properties'), exceptionFactory)
+        entries = FilePropertiesEntries.create(new File('notThere.properties'), exceptionFactory)
 
         try {
             entries['any'].string
@@ -133,7 +133,7 @@ class FilePropertiesEntriesTest {
         def additionalMessage = 'This file should contain the following properties:\n- foo\n- bar'
         def consoleRenderer = new ConsoleRenderer()
         exceptionFactory.additionalMessage = additionalMessage
-        entries = FilePropertiesEntries.create('notThere', new File('notThere.properties'), exceptionFactory)
+        entries = FilePropertiesEntries.create(new File('notThere.properties'), exceptionFactory)
 
         try {
             entries['any'].string


### PR DESCRIPTION
### Scope of the PR
While working on a new feature I realised we don't need to hold the name of the property set in the `FilePropertiesEntries`, as it would be only needed to create error messages (and we already have that property available in `ExceptionFactory`.
