### PR TITLE
Tweak public API

### DIFF
--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -20,20 +20,16 @@ class BuildProperties {
         name
     }
 
-    void using(Map<String, Object> map) {
-        entries(new MapEntries(map, exceptionFactory))
-    }
-
-    void using(File file) {
-        entries(FilePropertiesEntries.create(file, exceptionFactory))
-    }
-
-    void entries(Entries entries) {
-        this.entries = entries
+    Entries getEntries() {
+        entries
     }
 
     Enumeration<String> getKeys() {
         entries.keys
+    }
+
+    ExceptionFactory getExceptionFactory() {
+        exceptionFactory
     }
 
     Entry getAt(String key) {
@@ -42,5 +38,17 @@ class BuildProperties {
 
     void setDescription(String description) {
         exceptionFactory.additionalMessage = description
+    }
+
+    void using(Map<String, Object> map) {
+        using(new MapEntries(map, exceptionFactory))
+    }
+
+    void using(File file) {
+        using(FilePropertiesEntries.create(file, exceptionFactory))
+    }
+
+    void using(Entries entries) {
+        this.entries = entries
     }
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -1,7 +1,6 @@
 package com.novoda.buildproperties
 
 import com.novoda.buildproperties.internal.DefaultExceptionFactory
-import com.novoda.buildproperties.internal.ExceptionFactory
 import com.novoda.buildproperties.internal.FilePropertiesEntries
 import com.novoda.buildproperties.internal.MapEntries
 

--- a/plugin/src/main/groovy/com/novoda/buildproperties/Entries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/Entries.groovy
@@ -1,19 +1,10 @@
 package com.novoda.buildproperties
 
-abstract class Entries {
+interface Entries {
 
-    Entries() {
-    }
+    boolean contains(String key)
 
-    abstract boolean contains(String key)
+    Entry getAt(String key)
 
-    protected abstract Object getValueAt(String key)
-
-    Entry getAt(String key) {
-        new Entry(key, {
-            getValueAt(key)
-        })
-    }
-
-    abstract Enumeration<String> getKeys()
+    Enumeration<String> getKeys()
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/ExceptionFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/ExceptionFactory.groovy
@@ -1,4 +1,4 @@
-package com.novoda.buildproperties.internal
+package com.novoda.buildproperties
 
 interface ExceptionFactory {
 

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultExceptionFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultExceptionFactory.groovy
@@ -1,5 +1,7 @@
 package com.novoda.buildproperties.internal
 
+import com.novoda.buildproperties.ExceptionFactory
+
 class DefaultExceptionFactory extends AdditionalMessageProvider implements ExceptionFactory {
 
     private final String propertiesSetName

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
@@ -2,6 +2,7 @@ package com.novoda.buildproperties.internal
 
 import com.novoda.buildproperties.Entries
 import com.novoda.buildproperties.Entry
+import com.novoda.buildproperties.ExceptionFactory
 
 class FilePropertiesEntries implements Entries {
 

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
@@ -1,8 +1,9 @@
 package com.novoda.buildproperties.internal
 
 import com.novoda.buildproperties.Entries
+import com.novoda.buildproperties.Entry
 
-class FilePropertiesEntries extends Entries {
+class FilePropertiesEntries implements Entries {
 
     private final Closure<PropertiesProvider> providerClosure
 
@@ -31,8 +32,10 @@ class FilePropertiesEntries extends Entries {
     }
 
     @Override
-    protected Object getValueAt(String key) {
-        provider.getValueAt(key)
+    Entry getAt(String key) {
+        new Entry(key, {
+            provider.getValueAt(key)
+        })
     }
 
     @Override

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
@@ -2,6 +2,7 @@ package com.novoda.buildproperties.internal
 
 import com.novoda.buildproperties.Entries
 import com.novoda.buildproperties.Entry
+import com.novoda.buildproperties.ExceptionFactory
 
 class MapEntries implements Entries {
     private final Map<String, Object> map

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
@@ -1,8 +1,9 @@
 package com.novoda.buildproperties.internal
 
 import com.novoda.buildproperties.Entries
+import com.novoda.buildproperties.Entry
 
-class MapEntries extends Entries {
+class MapEntries implements Entries {
     private final Map<String, Object> map
     private final ExceptionFactory exceptionFactory
 
@@ -19,12 +20,14 @@ class MapEntries extends Entries {
     }
 
     @Override
-    protected Object getValueAt(String key) {
-        Object value = map.get(key)
-        if (value != null) {
-            return value
-        }
-        throw exceptionFactory.propertyNotFound(key)
+    Entry getAt(String key) {
+        new Entry(key, {
+            Object value = map.get(key)
+            if (value != null) {
+                return value
+            }
+            throw exceptionFactory.propertyNotFound(key)
+        })
     }
 
     @Override


### PR DESCRIPTION
- `Entries` is now an interface
- `BuildProperties` exposes another overload for `using(Entries)` that can be used to create custom entry set implementations
- `ExceptionFactory` has been promoted as public API