### PR TITLE
Expose Map<String, Entry> from Entries

### DIFF
--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -35,6 +35,10 @@ class BuildProperties {
         entries.getAt(key)
     }
 
+    Map<String, Entry> asMap() {
+        entries.asMap()
+    }
+
     void setDescription(String description) {
         exceptionFactory.additionalMessage = description
     }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/Entries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/Entries.groovy
@@ -7,4 +7,6 @@ interface Entries {
     Entry getAt(String key)
 
     Enumeration<String> getKeys()
+
+    Map<String, Entry> asMap()
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/Entries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/Entries.groovy
@@ -1,12 +1,17 @@
 package com.novoda.buildproperties
 
-interface Entries {
+abstract class Entries {
 
-    boolean contains(String key)
+    abstract boolean contains(String key)
 
-    Entry getAt(String key)
+    abstract Entry getAt(String key)
 
-    Enumeration<String> getKeys()
+    abstract Enumeration<String> getKeys()
 
-    Map<String, Entry> asMap()
+    final Map<String, Entry> asMap() {
+        Map<String, Entry> entryMap = keys.toList().collectEntries {
+            [(it): this[it]]
+        }
+        Collections.unmodifiableMap(entryMap)
+    }
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
@@ -4,7 +4,7 @@ import com.novoda.buildproperties.Entries
 import com.novoda.buildproperties.Entry
 import com.novoda.buildproperties.ExceptionFactory
 
-class FilePropertiesEntries implements Entries {
+class FilePropertiesEntries extends Entries {
 
     private final Closure<PropertiesProvider> providerClosure
 
@@ -19,7 +19,6 @@ class FilePropertiesEntries implements Entries {
     }
 
     private FilePropertiesEntries(Closure<PropertiesProvider> providerClosure) {
-        super()
         this.providerClosure = providerClosure.memoize()
     }
 
@@ -42,14 +41,6 @@ class FilePropertiesEntries implements Entries {
     @Override
     Enumeration<String> getKeys() {
         provider.keys
-    }
-
-    @Override
-    Map<String, Entry> asMap() {
-        Map<String, Entry> entryMap = keys.toList().collectEntries {
-            [(it): this[it]]
-        }
-        Collections.unmodifiableMap(entryMap)
     }
 
     private static class PropertiesProvider {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
@@ -46,7 +46,10 @@ class FilePropertiesEntries implements Entries {
 
     @Override
     Map<String, Entry> asMap() {
-        return null
+        Map<String, Entry> entryMap = keys.toList().collectEntries {
+            [(it): this[it]]
+        }
+        Collections.unmodifiableMap(entryMap)
     }
 
     private static class PropertiesProvider {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
@@ -44,6 +44,10 @@ class FilePropertiesEntries implements Entries {
         provider.keys
     }
 
+    @Override
+    Map<String, Entry> asMap() {
+        return null
+    }
 
     private static class PropertiesProvider {
         final File file

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
@@ -4,13 +4,12 @@ import com.novoda.buildproperties.Entries
 import com.novoda.buildproperties.Entry
 import com.novoda.buildproperties.ExceptionFactory
 
-class MapEntries implements Entries {
+class MapEntries extends Entries {
     private final Map<String, Object> map
     private final ExceptionFactory exceptionFactory
 
     MapEntries(Map<String, Object> map,
                ExceptionFactory exceptionFactory) {
-        super()
         this.exceptionFactory = exceptionFactory
         this.map = Collections.unmodifiableMap(map)
     }
@@ -34,13 +33,5 @@ class MapEntries implements Entries {
     @Override
     Enumeration<String> getKeys() {
         Collections.enumeration(map.keySet())
-    }
-
-    @Override
-    Map<String, Entry> asMap() {
-        Map<String, Entry> entryMap = map.keySet().collectEntries {
-            [(it): this[it]]
-        }
-        Collections.unmodifiableMap(entryMap)
     }
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/MapEntries.groovy
@@ -35,4 +35,12 @@ class MapEntries implements Entries {
     Enumeration<String> getKeys() {
         Collections.enumeration(map.keySet())
     }
+
+    @Override
+    Map<String, Entry> asMap() {
+        Map<String, Entry> entryMap = map.keySet().collectEntries {
+            [(it): this[it]]
+        }
+        Collections.unmodifiableMap(entryMap)
+    }
 }

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
@@ -1,7 +1,6 @@
 package com.novoda.buildproperties.internal
 
 import com.google.common.io.Resources
-import com.novoda.buildproperties.Entry
 import org.junit.Before
 import org.junit.Test
 
@@ -10,11 +9,12 @@ import static org.junit.Assert.fail
 
 class FilePropertiesEntriesTest {
 
-    private static final File PROPERTIES_FILE = new File(Resources.getResource('any.properties').toURI())
+    private static
+    final File PROPERTIES_FILE = new File(Resources.getResource('any.properties').toURI())
 
     private DefaultExceptionFactory exceptionFactory
     private AdditionalMessageProvider additionalMessageProvider
-    
+
     private FilePropertiesEntries entries
 
     @Before
@@ -27,7 +27,7 @@ class FilePropertiesEntriesTest {
     @Test
     void shouldNotAccessPropertyValueWhenGettingEntry() {
         try {
-            Entry entry = entries['notThere']
+            entries['notThere']
         } catch (IllegalArgumentException ignored) {
             fail('Entry value should be evaluated lazily')
         }
@@ -143,5 +143,29 @@ class FilePropertiesEntriesTest {
             assertThat(message).contains('notThere.properties does not exist.')
             assertThat(message).contains(consoleRenderer.indent(additionalMessage, "* buildProperties.foo: "))
         }
+    }
+
+    @Test
+    void shouldProvideEntriesAsMap() {
+        def map = entries.asMap()
+
+        assertThat(map).containsKey('aProperty')
+        assertThat(map['aProperty']).hasValue('qwerty')
+    }
+
+    @Test
+    void shouldIterateOverValues() {
+        def values = entries.asMap().values()*.string
+
+        assertThat(values).containsExactly(
+                'qwerty',
+                'asdfg',
+                '?????',
+                'false',
+                'true',
+                '123456',
+                '0.001',
+                'hello world'
+        )
     }
 }

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
@@ -9,9 +9,8 @@ import static org.junit.Assert.fail
 
 class FilePropertiesEntriesTest {
 
-    private static
-    final File PROPERTIES_FILE = new File(Resources.getResource('any.properties').toURI())
-
+    private static final File ANY_PROPERTIES = resourceFile('any.properties')
+    private static final File NOT_THERE_PROPERTIES = new File('notThere.properties')
     private DefaultExceptionFactory exceptionFactory
     private AdditionalMessageProvider additionalMessageProvider
 
@@ -21,7 +20,7 @@ class FilePropertiesEntriesTest {
     void setUp() {
         additionalMessageProvider = new AdditionalMessageProvider()
         exceptionFactory = new DefaultExceptionFactory('foo')
-        entries = FilePropertiesEntries.create(PROPERTIES_FILE, exceptionFactory)
+        entries = FilePropertiesEntries.create(ANY_PROPERTIES, exceptionFactory)
     }
 
     @Test
@@ -105,8 +104,8 @@ class FilePropertiesEntriesTest {
 
     @Test
     void shouldRecursivelyIncludePropertiesFromSpecifiedFilesWhenIncludeProvided() {
-        def moreEntries = FilePropertiesEntries.create(new File(Resources.getResource('more.properties').toURI()), exceptionFactory)
-        def includingEntries = FilePropertiesEntries.create(new File(Resources.getResource('including.properties').toURI()), exceptionFactory)
+        def moreEntries = FilePropertiesEntries.create(resourceFile('more.properties'), exceptionFactory)
+        def includingEntries = FilePropertiesEntries.create(resourceFile('including.properties'), exceptionFactory)
 
         entries.keys.each { String key ->
             assertThat(moreEntries[key].string).isEqualTo(entries[key].string)
@@ -118,7 +117,7 @@ class FilePropertiesEntriesTest {
 
     @Test
     void shouldThrowExceptionWhenAccessingPropertyFromNonExistentPropertiesFile() {
-        entries = FilePropertiesEntries.create(new File('notThere.properties'), exceptionFactory)
+        entries = FilePropertiesEntries.create(NOT_THERE_PROPERTIES, exceptionFactory)
 
         try {
             entries['any'].string
@@ -133,7 +132,7 @@ class FilePropertiesEntriesTest {
         def additionalMessage = 'This file should contain the following properties:\n- foo\n- bar'
         def consoleRenderer = new ConsoleRenderer()
         exceptionFactory.additionalMessage = additionalMessage
-        entries = FilePropertiesEntries.create(new File('notThere.properties'), exceptionFactory)
+        entries = FilePropertiesEntries.create(NOT_THERE_PROPERTIES, exceptionFactory)
 
         try {
             entries['any'].string
@@ -167,5 +166,9 @@ class FilePropertiesEntriesTest {
                 '0.001',
                 'hello world'
         )
+    }
+
+    private static File resourceFile(String file) {
+        new File(Resources.getResource(file).toURI())
     }
 }

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/MapEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/MapEntriesTest.groovy
@@ -48,6 +48,25 @@ class MapEntriesTest {
         assertThat(Collections.list(keys)).containsAllOf('foo', 'x')
     }
 
+    @Test
+    void shouldProvideEntriesAsMap() {
+        def entries = givenMapEntries([foo: 'bar', x: 'y'])
+
+        def map = entries.asMap()
+
+        assertThat(map).containsKey('foo')
+        assertThat(map['foo']).hasValue('bar')
+    }
+
+    @Test
+    void shouldIterateOverValues() {
+        def entries = givenMapEntries([foo: 'bar', x: 'y'])
+
+        def values = entries.asMap().values()*.string
+
+        assertThat(values).containsExactly('bar', 'y')
+    }
+
     private static MapEntries givenMapEntries(Map<String, Object> properties) {
         new MapEntries(properties, new DefaultExceptionFactory('foo'))
     }


### PR DESCRIPTION
Fixes #40 

Providing `Map` has a huge benefit because it allows users to use standard groovy lib methods defined over map interface. 

It is also easy to just implement `Map` but we don't like it since it is a mutable interface. 

Instead, This PR provides an immutable copy of `Entries` as a `Map<String, Entry>` accessed via `asMap()` method. 

### Questions

Since `Entries` is now an interface, I have duplicated implementation in this PR. I can think of classic alternatives. Since I'm not familiar with project's convention on this, I wanted to discuss first.

- Make it again `abstract class` 
- Use `Groovy`'s `trait`
- Have a collaborator or a static utility class to have this conversion.
- Make project target java 1.8 and use `default` methods.