### PR TITLE
Introduce entries chain

### DIFF
--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -1,18 +1,17 @@
 package com.novoda.buildproperties
 
+import com.novoda.buildproperties.internal.DefaultEntriesFactory
 import com.novoda.buildproperties.internal.DefaultExceptionFactory
-import com.novoda.buildproperties.internal.FilePropertiesEntries
-import com.novoda.buildproperties.internal.MapEntries
 
 class BuildProperties {
 
     private final String name
-    private final ExceptionFactory exceptionFactory
-    private Entries entries
+    private final Entries.Factory factory
+    private EntriesChain chain
 
     BuildProperties(String name) {
         this.name = name
-        this.exceptionFactory = new DefaultExceptionFactory(name)
+        this.factory = new DefaultEntriesFactory(new DefaultExceptionFactory(name))
     }
 
     String getName() {
@@ -20,11 +19,11 @@ class BuildProperties {
     }
 
     Entries getEntries() {
-        entries
+        chain
     }
 
     Enumeration<String> getKeys() {
-        entries.keys
+        chain.keys
     }
 
     ExceptionFactory getExceptionFactory() {
@@ -32,22 +31,27 @@ class BuildProperties {
     }
 
     Entry getAt(String key) {
-        entries.getAt(key)
+        chain.getAt(key)
     }
 
     void setDescription(String description) {
-        exceptionFactory.additionalMessage = description
+        factory.additionalMessage = description
     }
 
-    void using(Map<String, Object> map) {
-        using(new MapEntries(map, exceptionFactory))
+    EntriesChain using(Map<String, Object> map) {
+        newChain(map)
     }
 
-    void using(File file) {
-        using(FilePropertiesEntries.create(file, exceptionFactory))
+    EntriesChain using(File file) {
+        newChain(file)
     }
 
-    void using(Entries entries) {
-        this.entries = entries
+    EntriesChain using(Entries entries) {
+        newChain(entries)
+    }
+
+    private EntriesChain newChain(def source) {
+        chain = new EntriesChain(factory, source)
+        return chain
     }
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/Entries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/Entries.groovy
@@ -7,4 +7,9 @@ interface Entries {
     Entry getAt(String key)
 
     Enumeration<String> getKeys()
+
+    interface Factory {
+
+        Entries from(def source)
+    }
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/EntriesChain.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/EntriesChain.groovy
@@ -1,0 +1,35 @@
+package com.novoda.buildproperties
+
+class EntriesChain implements Entries {
+
+    private final Entries.Factory entriesFactory
+    private final List<Entries> chain = []
+
+    EntriesChain(Entries.Factory entriesFactory, def source) {
+        this.entriesFactory = entriesFactory
+        chain.add(entriesFactory.from(source))
+    }
+
+    EntriesChain or(def source) {
+        chain.add(entriesFactory.from(source))
+        return this
+    }
+
+    @Override
+    boolean contains(String key) {
+        chain.find { it.contains(key) } != null
+    }
+
+    @Override
+    Entry getAt(String key) {
+        chain.inject((Entry) null) { Entry result, Entries entries ->
+            return result == null ? entries[key] : result.or(entries[key])
+        }
+    }
+
+    @Override
+    Enumeration<String> getKeys() {
+        Set<String> allKeys = chain.collect { it.keys.toList() }.flatten().toSet()
+        Collections.<String> enumeration(allKeys)
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/buildproperties/ExceptionFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/ExceptionFactory.groovy
@@ -1,8 +1,10 @@
 package com.novoda.buildproperties
 
-interface ExceptionFactory {
+import com.novoda.buildproperties.internal.AdditionalMessageProvider
 
-    Exception fileNotFound(File file)
+abstract class ExceptionFactory extends AdditionalMessageProvider {
 
-    Exception propertyNotFound(String key)
+    abstract Exception fileNotFound(File file)
+
+    abstract Exception propertyNotFound(String key)
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/AdditionalMessageProvider.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/AdditionalMessageProvider.groovy
@@ -1,8 +1,6 @@
 package com.novoda.buildproperties.internal
 
-import javax.inject.Provider
-
-class AdditionalMessageProvider implements Provider<String> {
+class AdditionalMessageProvider {
     private String additionalMessage = ''
 
     void setAdditionalMessage(String value) {
@@ -14,11 +12,6 @@ class AdditionalMessageProvider implements Provider<String> {
     }
 
     String getAdditionalMessage() {
-        additionalMessage
-    }
-
-    @Override
-    String get() {
         additionalMessage
     }
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/BuildPropertiesException.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/BuildPropertiesException.groovy
@@ -33,16 +33,16 @@ class BuildPropertiesException extends Exception {
         List<String> newAdditionalMessages = new ArrayList<>(additionalMessages)
         if (throwable instanceof BuildPropertiesException) {
             def other = (BuildPropertiesException) throwable
-            newExceptions.addAll(removeDuplicateExceptions(other.exceptions))
+            newExceptions.addAll(removeDuplicateExceptions(message, other.exceptions))
             newAdditionalMessages.addAll(removeDuplicateAdditionalMessages(other.additionalMessages))
         } else {
-            newExceptions.addAll(removeDuplicateExceptions([throwable]))
+            newExceptions.addAll(removeDuplicateExceptions(message, [throwable]))
         }
         return new BuildPropertiesException(newExceptions, newAdditionalMessages)
     }
 
-    private List<Throwable> removeDuplicateExceptions(List<Throwable> others) {
-        others.findAll { !message.contains(it.message) }
+    private static List<Throwable> removeDuplicateExceptions(String currentMessage, List<Throwable> throwables) {
+        throwables.findAll { !currentMessage.contains(it.message) }
     }
 
     private List<String> removeDuplicateAdditionalMessages(List<String> messages) {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/BuildPropertiesException.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/BuildPropertiesException.groovy
@@ -34,7 +34,7 @@ class BuildPropertiesException extends Exception {
         if (throwable instanceof BuildPropertiesException) {
             def other = (BuildPropertiesException) throwable
             newExceptions.addAll(removeDuplicateExceptions(message, other.exceptions))
-            newAdditionalMessages.addAll(removeDuplicateAdditionalMessages(other.additionalMessages))
+            newAdditionalMessages.addAll(other.additionalMessages - additionalMessages)
         } else {
             newExceptions.addAll(removeDuplicateExceptions(message, [throwable]))
         }
@@ -43,10 +43,6 @@ class BuildPropertiesException extends Exception {
 
     private static List<Throwable> removeDuplicateExceptions(String currentMessage, List<Throwable> throwables) {
         throwables.findAll { !currentMessage.contains(it.message) }
-    }
-
-    private List<String> removeDuplicateAdditionalMessages(List<String> messages) {
-        messages.findAll { !additionalMessages.contains(it) }
     }
 
     List<Throwable> getExceptions() {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/BuildPropertiesException.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/BuildPropertiesException.groovy
@@ -32,12 +32,21 @@ class BuildPropertiesException extends Exception {
         List<Throwable> newExceptions = new ArrayList<>(exceptions)
         List<String> newAdditionalMessages = new ArrayList<>(additionalMessages)
         if (throwable instanceof BuildPropertiesException) {
-            newExceptions.addAll(((BuildPropertiesException) throwable).exceptions)
-            newAdditionalMessages.addAll(((BuildPropertiesException) throwable).additionalMessages)
+            def other = (BuildPropertiesException) throwable
+            newExceptions.addAll(removeDuplicateExceptions(other.exceptions))
+            newAdditionalMessages.addAll(removeDuplicateAdditionalMessages(other.additionalMessages))
         } else {
-            newExceptions.add(throwable)
+            newExceptions.addAll(removeDuplicateExceptions([throwable]))
         }
         return new BuildPropertiesException(newExceptions, newAdditionalMessages)
+    }
+
+    private List<Throwable> removeDuplicateExceptions(List<Throwable> others) {
+        others.findAll { !message.contains(it.message) }
+    }
+
+    private List<String> removeDuplicateAdditionalMessages(List<String> messages) {
+        messages.findAll { !additionalMessages.contains(it) }
     }
 
     List<Throwable> getExceptions() {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactory.groovy
@@ -1,0 +1,30 @@
+package com.novoda.buildproperties.internal
+
+import com.novoda.buildproperties.BuildProperties
+import com.novoda.buildproperties.Entries
+import com.novoda.buildproperties.ExceptionFactory
+import org.gradle.api.GradleException
+
+class DefaultEntriesFactory implements Entries.Factory {
+
+    private final ExceptionFactory exceptionFactory
+
+    DefaultEntriesFactory(ExceptionFactory exceptionFactory) {
+        this.exceptionFactory = exceptionFactory
+    }
+
+    @Override
+    Entries from(def source) {
+        if (source instanceof BuildProperties) {
+            return source.entries
+        }else if (source instanceof Entries) {
+            return source as Entries
+        } else if (source instanceof Map<String, Object>) {
+            return new MapEntries(source, exceptionFactory)
+        } else if (source instanceof File) {
+            return FilePropertiesEntries.create(source, exceptionFactory)
+        } else {
+            throw new GradleException("Unsupported type of source (${source.class})")
+        }
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactory.groovy
@@ -15,16 +15,17 @@ class DefaultEntriesFactory implements Entries.Factory {
 
     @Override
     Entries from(def source) {
-        if (source instanceof BuildProperties) {
-            return source.entries
-        } else if (source instanceof Entries) {
-            return source as Entries
-        } else if (source instanceof Map<String, Object>) {
-            return new MapEntries(source, exceptionFactory)
-        } else if (source instanceof File) {
-            return FilePropertiesEntries.create(source, exceptionFactory)
-        } else {
-            throw new GradleException("Unsupported type of source (${source.class})")
+        switch (source) {
+            case BuildProperties:
+                return source.entries
+            case Entries:
+                return source as Entries
+            case { it instanceof Map<String, Object> }:
+                return new MapEntries(source, exceptionFactory)
+            case File:
+                return FilePropertiesEntries.create(source, exceptionFactory)
+            default:
+                throw new GradleException("Unsupported type of source (${source.class})")
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactory.groovy
@@ -17,7 +17,7 @@ class DefaultEntriesFactory implements Entries.Factory {
     Entries from(def source) {
         if (source instanceof BuildProperties) {
             return source.entries
-        }else if (source instanceof Entries) {
+        } else if (source instanceof Entries) {
             return source as Entries
         } else if (source instanceof Map<String, Object>) {
             return new MapEntries(source, exceptionFactory)
@@ -26,5 +26,9 @@ class DefaultEntriesFactory implements Entries.Factory {
         } else {
             throw new GradleException("Unsupported type of source (${source.class})")
         }
+    }
+
+    void setAdditionalMessage(String value) {
+        exceptionFactory.additionalMessage = value
     }
 }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultExceptionFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultExceptionFactory.groovy
@@ -2,7 +2,7 @@ package com.novoda.buildproperties.internal
 
 import com.novoda.buildproperties.ExceptionFactory
 
-class DefaultExceptionFactory extends AdditionalMessageProvider implements ExceptionFactory {
+class DefaultExceptionFactory extends ExceptionFactory {
 
     private final String propertiesSetName
     private final ConsoleRenderer consoleRenderer

--- a/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesExceptionTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesExceptionTest.groovy
@@ -43,4 +43,12 @@ class BuildPropertiesExceptionTest {
         assertThat(compositeException).hasMessage(EXCEPTION_1.message, EXCEPTION_2.message, EXCEPTION_3.message)
     }
 
+    @Test
+    void shouldNotContainDuplicateCompositeExceptionMessage() {
+        BuildPropertiesException innerException = BuildPropertiesException.from(EXCEPTION_1).add(EXCEPTION_2)
+
+        BuildPropertiesException compositeException = innerException.add(EXCEPTION_1)
+
+        assertThat(compositeException).hasMessage(EXCEPTION_1.message, EXCEPTION_2.message)
+    }
 }

--- a/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
@@ -139,6 +139,30 @@ class BuildPropertiesTest {
         assertThat(project.buildProperties.test['f']).hasValue('value_f')
     }
 
+    @Test
+    void shouldReturnFallbackValuesWhenChainOfEntries() {
+        File propertiesFile = newPropertiesFile('test.properties', 'd=value_d\ne=value_e\nf=value_f')
+
+        project.buildProperties {
+            map {
+                using([a: 'value_a', b: 'value_b', c: 'value_c'])
+            }
+            test {
+                using propertiesFile
+            }
+            chain {
+                using(propertiesFile).or(map)
+            }
+        }
+
+        assertThat(project.buildProperties.chain['a']).hasValue('value_a')
+        assertThat(project.buildProperties.chain['b']).hasValue('value_b')
+        assertThat(project.buildProperties.chain['c']).hasValue('value_c')
+        assertThat(project.buildProperties.chain['d']).hasValue('value_d')
+        assertThat(project.buildProperties.chain['e']).hasValue('value_e')
+        assertThat(project.buildProperties.chain['f']).hasValue('value_f')
+    }
+
     private File newPropertiesFile(String fileName, String fileContent) {
         File propertiesFile = temp.newFile(fileName)
         propertiesFile.text = fileContent

--- a/plugin/src/test/groovy/com/novoda/buildproperties/EntriesChainTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/EntriesChainTest.groovy
@@ -1,0 +1,80 @@
+package com.novoda.buildproperties
+
+import com.novoda.buildproperties.internal.DefaultEntriesFactory
+import com.novoda.buildproperties.internal.DefaultExceptionFactory
+import org.junit.Before
+import org.junit.Test
+
+import static com.novoda.buildproperties.test.ExtendedTruth.assertThat
+
+class EntriesChainTest {
+
+    private static final ExceptionFactory DEFAULT_EXCEPTION_FACTORY = new DefaultExceptionFactory('default')
+    private static final Entries.Factory DEFAULT_ENTRIES_FACTORY = new DefaultEntriesFactory(DEFAULT_EXCEPTION_FACTORY)
+    private static final ExceptionFactory FALLBACK_EXCEPTION_FACTORY = new DefaultExceptionFactory('fallback')
+    private static final Entries.Factory FALLBACK_ENTRIES_FACTORY = new DefaultEntriesFactory(FALLBACK_EXCEPTION_FACTORY)
+    private static final Map<String, Object> DEFAULT_MAP = [a: 'value_a', b: 'value_b', c: 'value_c', d: 'value_d']
+    private static final Map<String, Object> FALLBACK_MAP = [d: 'none', e: 'value_e', f: 'value_f']
+    private EntriesChain chain
+
+    @Before
+    void setUp() {
+        chain = new EntriesChain(DEFAULT_ENTRIES_FACTORY, DEFAULT_MAP)
+    }
+
+    @Test
+    void shouldContainAllValuesFromGivenMap() {
+        def entries = chain
+
+        assertThat(entries['a']).hasValue('value_a')
+        assertThat(entries['b']).hasValue('value_b')
+        assertThat(entries['c']).hasValue('value_c')
+        assertThat(entries['d']).hasValue('value_d')
+    }
+
+    @Test
+    void shouldContainAllKeysFromGivenMap() {
+        def entries = chain
+
+        assertThat(Collections.list(entries.keys)).containsExactly('a', 'b', 'c', 'd')
+    }
+
+    @Test
+    void shouldIncludeValuesFromFallbackMap() {
+        def entries = chain.or(FALLBACK_MAP)
+
+        assertThat(entries['e']).hasValue('value_e')
+        assertThat(entries['f']).hasValue('value_f')
+    }
+
+    @Test
+    void shouldContainAllKeysFromBothMaps() {
+        def entries = chain.or(FALLBACK_MAP)
+
+        assertThat(Collections.list(entries.keys)).containsExactly('a', 'b', 'c', 'd', 'e', 'f')
+    }
+
+    @Test
+    void shouldThrowExceptionWhenKeyNotFoundInAnyEntries() {
+        try {
+            def entries = chain.or(FALLBACK_MAP)
+            entries['x'].string
+        } catch (Exception e) {
+            def propertyNotFound = DEFAULT_EXCEPTION_FACTORY.propertyNotFound('x')
+            assertThat(e.message).isEqualTo(propertyNotFound.message)
+        }
+    }
+
+    @Test
+    void shouldMentionErrorMessageFromFallbackEntries() {
+        def fallbackEntries = FALLBACK_ENTRIES_FACTORY.from(FALLBACK_MAP)
+        try {
+            def entries = chain.or(fallbackEntries)
+            entries['x'].string
+        } catch (Exception e) {
+            assertThat(e.message).startsWith('Build properties evaluation failed:')
+            assertThat(e.message).contains('Unable to find value for key \'x\' in properties set \'buildProperties.default\'.')
+            assertThat(e.message).contains('Unable to find value for key \'x\' in properties set \'buildProperties.fallback\'.')
+        }
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/buildproperties/test/BuildPropertiesExceptionSubject.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/test/BuildPropertiesExceptionSubject.groovy
@@ -28,6 +28,6 @@ final class BuildPropertiesExceptionSubject extends Subject<BuildPropertiesExcep
     }
 
     void hasMessage(String... messages) {
-        Truth.assertThat(subject.exceptions.collect { it.message }).containsExactly(messages)
+        Truth.assertThat(actual().exceptions.collect { it.message }).containsExactly(messages)
     }
 }


### PR DESCRIPTION
### Scope of the PR
This PR is bringing the fallback support for a whole set of entries, similarly to what already happens to a single `Entry`. The aim is to define a chain of properties sets via the `or` operator, eg:

```
buildProperties {
  foo {
    using(...).or(...)
  }
  bar {
    using(...).or(foo)
  }
}
```
where `...` can be a valid source for an entries set, like a `Map`, a properties file or an instance of `Entries`.

### Considerations/Implementation Details
`BuildProperties.using()` now returns `EntriesChain`, that is an `Entries` implementation that provides the `or` operator we need for the DSL above. The collection of exceptions when an entry is evaluated can now lead to duplicate error messages, so some changes have been introduced in order to avoid that too.

Note: if we're happy with this new DSL and overall implementation I will then issue a follow-up PR cleaning up the `FilePropertiesEntries` implementation in order to use the new facilities to achieve inheritance over properties files.