### PR TITLE
Deprecate include properties files

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     testCompile 'com.android.tools.build:gradle:2.2.0'
     testCompile 'com.google.code.findbugs:jsr305:3.0.0'
     testCompile 'com.github.stefanbirkner:system-rules:1.16.0'
-
+    testCompile 'org.mockito:mockito-core:2.13.0'
 }
 
 // https://code.google.com/p/android/issues/detail?id=64887

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -7,14 +7,12 @@ import org.gradle.api.Project
 class BuildProperties {
 
     private final String name
-    private final Project project
     private final DefaultEntriesFactory factory
     private EntriesChain chain
 
     BuildProperties(String name, Project project) {
         this.name = name
-        this.project = project
-        this.factory = new DefaultEntriesFactory(new DefaultExceptionFactory(name))
+        this.factory = new DefaultEntriesFactory(project.logger, new DefaultExceptionFactory(name))
     }
 
     String getName() {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -55,6 +55,10 @@ class BuildProperties {
         newChain(entries)
     }
 
+    EntriesChain using(BuildProperties buildProperties) {
+        newChain(buildProperties.entries)
+    }
+
     private EntriesChain newChain(def source) {
         chain = new EntriesChain(factory, source)
         return chain

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -6,7 +6,7 @@ import com.novoda.buildproperties.internal.DefaultExceptionFactory
 class BuildProperties {
 
     private final String name
-    private final Entries.Factory factory
+    private final DefaultEntriesFactory factory
     private EntriesChain chain
 
     BuildProperties(String name) {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -2,15 +2,18 @@ package com.novoda.buildproperties
 
 import com.novoda.buildproperties.internal.DefaultEntriesFactory
 import com.novoda.buildproperties.internal.DefaultExceptionFactory
+import org.gradle.api.Project
 
 class BuildProperties {
 
     private final String name
+    private final Project project
     private final DefaultEntriesFactory factory
     private EntriesChain chain
 
-    BuildProperties(String name) {
+    BuildProperties(String name, Project project) {
         this.name = name
+        this.project = project
         this.factory = new DefaultEntriesFactory(new DefaultExceptionFactory(name))
     }
 

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildPropertiesPlugin.groovy
@@ -11,7 +11,7 @@ class BuildPropertiesPlugin implements Plugin<Project> {
         def container = project.container(BuildProperties, new NamedDomainObjectFactory<BuildProperties>() {
             @Override
             BuildProperties create(String name) {
-                return new BuildProperties(name)
+                return new BuildProperties(name, project)
             }
         })
         project.extensions.add('buildProperties', container)

--- a/plugin/src/main/groovy/com/novoda/buildproperties/EntriesChain.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/EntriesChain.groovy
@@ -2,7 +2,7 @@ package com.novoda.buildproperties
 
 class EntriesChain extends Entries {
 
-    private final Factory entriesFactory
+    private final Entries.Factory entriesFactory
     private final List<Entries> chain = []
 
     EntriesChain(Entries.Factory entriesFactory, def source) {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/Entry.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/Entry.groovy
@@ -36,7 +36,7 @@ class Entry {
         getValue() as String
     }
 
-    private Object getValue() {
+    Object getValue() {
         value.call()
     }
 

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactory.groovy
@@ -2,6 +2,7 @@ package com.novoda.buildproperties.internal
 
 import com.novoda.buildproperties.BuildProperties
 import com.novoda.buildproperties.Entries
+import com.novoda.buildproperties.EntriesChain
 import com.novoda.buildproperties.ExceptionFactory
 import org.gradle.api.GradleException
 import org.gradle.api.logging.Logger
@@ -33,7 +34,24 @@ class DefaultEntriesFactory implements Entries.Factory {
     }
 
     private Entries newFilePropertiesEntries(File file) {
-        FilePropertiesEntries.create(file, exceptionFactory)
+        def entries = FilePropertiesEntries.create(file, exceptionFactory)
+        if (!entries.contains('include')) {
+            return entries
+        }
+        def includeFile = new File(file.parentFile, entries['include'].string)
+        if (!includeFile.exists()) {
+            return entries
+        }
+        logger.warn("""/!\\ WARNING /!\\ Detected use of 'include' property to model inheritance between properties files. 
+                       |                 This feature is deprecated and will be removed in an upcoming release, please use or() operator instead.
+                       |                 For instance you could do:
+                       |                 
+                       |                    buildProperties {
+                       |                        using(file('$file.name')).or(file('$includeFile.name'))
+                       |                    }
+                       |
+                       |""".stripMargin())
+        new EntriesChain(this, entries).or(from(includeFile))
     }
 
     void setAdditionalMessage(String value) {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactory.groovy
@@ -4,12 +4,15 @@ import com.novoda.buildproperties.BuildProperties
 import com.novoda.buildproperties.Entries
 import com.novoda.buildproperties.ExceptionFactory
 import org.gradle.api.GradleException
+import org.gradle.api.logging.Logger
 
 class DefaultEntriesFactory implements Entries.Factory {
 
+    private final Logger logger
     private final ExceptionFactory exceptionFactory
 
-    DefaultEntriesFactory(ExceptionFactory exceptionFactory) {
+    DefaultEntriesFactory(Logger logger, ExceptionFactory exceptionFactory) {
+        this.logger = logger
         this.exceptionFactory = exceptionFactory
     }
 
@@ -21,12 +24,16 @@ class DefaultEntriesFactory implements Entries.Factory {
             case Entries:
                 return source as Entries
             case { it instanceof Map<String, Object> }:
-                return new MapEntries(source, exceptionFactory)
+                return new MapEntries(source as Map<String, Object>, exceptionFactory)
             case File:
-                return FilePropertiesEntries.create(source, exceptionFactory)
+                return newFilePropertiesEntries(source as File)
             default:
                 throw new GradleException("Unsupported type of source (${source.class})")
         }
+    }
+
+    private FilePropertiesEntries newFilePropertiesEntries(File file) {
+        FilePropertiesEntries.create(file, exceptionFactory)
     }
 
     void setAdditionalMessage(String value) {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactory.groovy
@@ -26,13 +26,13 @@ class DefaultEntriesFactory implements Entries.Factory {
             case { it instanceof Map<String, Object> }:
                 return new MapEntries(source as Map<String, Object>, exceptionFactory)
             case File:
-                return newFilePropertiesEntries(source as File)
+                return new LazyEntries({ newFilePropertiesEntries(source as File) })
             default:
                 throw new GradleException("Unsupported type of source (${source.class})")
         }
     }
 
-    private FilePropertiesEntries newFilePropertiesEntries(File file) {
+    private Entries newFilePropertiesEntries(File file) {
         FilePropertiesEntries.create(file, exceptionFactory)
     }
 

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
@@ -65,7 +65,7 @@ class FilePropertiesEntries extends Entries {
             this.exceptionFactory = exceptionFactory
             this.keys = new HashSet<>(properties.stringPropertyNames())
             if (defaults != null) {
-                this.keys.addAll(defaults.keys)
+                this.keys.addAll(defaults.keys.toSet())
             }
         }
 

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/FilePropertiesEntries.groovy
@@ -4,20 +4,32 @@ import com.novoda.buildproperties.Entries
 import com.novoda.buildproperties.Entry
 import com.novoda.buildproperties.ExceptionFactory
 
-class FilePropertiesEntries extends LazyEntries {
+class FilePropertiesEntries extends Entries {
+
+    private final Entries entries
 
     static FilePropertiesEntries create(File file,
                                         ExceptionFactory exceptionFactory) {
-        new FilePropertiesEntries({
-            if (!file.exists()) {
-                throw exceptionFactory.fileNotFound(file)
-            }
-            PropertiesProvider.create(file, exceptionFactory)
-        })
+        new FilePropertiesEntries(PropertiesProvider.create(file, exceptionFactory))
     }
 
-    private FilePropertiesEntries(Closure<Entries> entriesClosure) {
-        super(entriesClosure)
+    private FilePropertiesEntries(Entries entries) {
+        this.entries = entries
+    }
+
+    @Override
+    boolean contains(String key) {
+        entries.contains(key)
+    }
+
+    @Override
+    Entry getAt(String key) {
+        entries.getAt(key)
+    }
+
+    @Override
+    Enumeration<String> getKeys() {
+        entries.getKeys()
     }
 
     private static class PropertiesProvider extends Entries {
@@ -28,6 +40,10 @@ class FilePropertiesEntries extends LazyEntries {
         final Set<String> keys
 
         static PropertiesProvider create(File file, ExceptionFactory exceptionFactory) {
+            if (!file.exists()) {
+                throw exceptionFactory.fileNotFound(file)
+            }
+
             Properties properties = new Properties()
             properties.load(new FileInputStream(file))
 

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/LazyEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/LazyEntries.groovy
@@ -3,7 +3,7 @@ package com.novoda.buildproperties.internal
 import com.novoda.buildproperties.Entries
 import com.novoda.buildproperties.Entry
 
-class LazyEntries implements Entries {
+class LazyEntries extends Entries {
 
     private final Closure<Entries> entriesClosure
 
@@ -11,7 +11,7 @@ class LazyEntries implements Entries {
         this.entriesClosure = entriesClosure.memoize()
     }
 
-    private Entries getEntries() {
+    protected Entries getEntries() {
         entriesClosure.call()
     }
 

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/LazyEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/LazyEntries.groovy
@@ -1,0 +1,34 @@
+package com.novoda.buildproperties.internal
+
+import com.novoda.buildproperties.Entries
+import com.novoda.buildproperties.Entry
+
+class LazyEntries implements Entries {
+
+    private final Closure<Entries> entriesClosure
+
+    LazyEntries(Closure<Entries> entriesClosure) {
+        this.entriesClosure = entriesClosure.memoize()
+    }
+
+    private Entries getEntries() {
+        entriesClosure.call()
+    }
+
+    @Override
+    boolean contains(String key) {
+        entries.contains(key)
+    }
+
+    @Override
+    Entry getAt(String key) {
+        new Entry(key, {
+            entries.getAt(key).getValue()
+        })
+    }
+
+    @Override
+    Enumeration<String> getKeys() {
+        entries.keys
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
@@ -150,8 +150,11 @@ class BuildPropertiesTest {
             test {
                 using propertiesFile
             }
+            notThere {
+                using(new File(temp.root, 'notThere.properties'))
+            }
             chain {
-                using(propertiesFile).or(map)
+                using(notThere).or(propertiesFile).or(map)
             }
         }
 

--- a/plugin/src/test/groovy/com/novoda/buildproperties/EntriesChainTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/EntriesChainTest.groovy
@@ -2,17 +2,20 @@ package com.novoda.buildproperties
 
 import com.novoda.buildproperties.internal.DefaultEntriesFactory
 import com.novoda.buildproperties.internal.DefaultExceptionFactory
+import org.gradle.api.logging.Logger
 import org.junit.Before
 import org.junit.Test
 
 import static com.novoda.buildproperties.test.ExtendedTruth.assertThat
+import static org.mockito.Mockito.mock
 
 class EntriesChainTest {
 
+    private static final Logger LOGGER = mock(Logger)
     private static final ExceptionFactory DEFAULT_EXCEPTION_FACTORY = new DefaultExceptionFactory('default')
-    private static final Entries.Factory DEFAULT_ENTRIES_FACTORY = new DefaultEntriesFactory(DEFAULT_EXCEPTION_FACTORY)
+    private static final DEFAULT_ENTRIES_FACTORY = new DefaultEntriesFactory(LOGGER, DEFAULT_EXCEPTION_FACTORY)
     private static final ExceptionFactory FALLBACK_EXCEPTION_FACTORY = new DefaultExceptionFactory('fallback')
-    private static final Entries.Factory FALLBACK_ENTRIES_FACTORY = new DefaultEntriesFactory(FALLBACK_EXCEPTION_FACTORY)
+    private static final FALLBACK_ENTRIES_FACTORY = new DefaultEntriesFactory(LOGGER, FALLBACK_EXCEPTION_FACTORY)
     private static final Map<String, Object> DEFAULT_MAP = [a: 'value_a', b: 'value_b', c: 'value_c', d: 'value_d']
     private static final Map<String, Object> FALLBACK_MAP = [d: 'none', e: 'value_e', f: 'value_f']
     private EntriesChain chain

--- a/plugin/src/test/groovy/com/novoda/buildproperties/EntriesChainTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/EntriesChainTest.groovy
@@ -13,9 +13,9 @@ class EntriesChainTest {
 
     private static final Logger LOGGER = mock(Logger)
     private static final ExceptionFactory DEFAULT_EXCEPTION_FACTORY = new DefaultExceptionFactory('default')
-    private static final DEFAULT_ENTRIES_FACTORY = new DefaultEntriesFactory(LOGGER, DEFAULT_EXCEPTION_FACTORY)
+    private static final Entries.Factory DEFAULT_ENTRIES_FACTORY = new DefaultEntriesFactory(LOGGER, DEFAULT_EXCEPTION_FACTORY)
     private static final ExceptionFactory FALLBACK_EXCEPTION_FACTORY = new DefaultExceptionFactory('fallback')
-    private static final FALLBACK_ENTRIES_FACTORY = new DefaultEntriesFactory(LOGGER, FALLBACK_EXCEPTION_FACTORY)
+    private static final Entries.Factory FALLBACK_ENTRIES_FACTORY = new DefaultEntriesFactory(LOGGER, FALLBACK_EXCEPTION_FACTORY)
     private static final Map<String, Object> DEFAULT_MAP = [a: 'value_a', b: 'value_b', c: 'value_c', d: 'value_d']
     private static final Map<String, Object> FALLBACK_MAP = [d: 'none', e: 'value_e', f: 'value_f']
     private EntriesChain chain

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactoryTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactoryTest.groovy
@@ -7,11 +7,16 @@ import com.novoda.buildproperties.ExceptionFactory
 import org.gradle.api.logging.Logger
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
 import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
 
 import static com.novoda.buildproperties.test.ExtendedTruth.assertThat
 import static org.junit.Assert.fail
+import static org.mockito.Mockito.verify
 
+@RunWith(MockitoJUnitRunner)
 class DefaultEntriesFactoryTest {
 
 
@@ -87,6 +92,20 @@ class DefaultEntriesFactoryTest {
         def allKeys = entries.keys.toSet()
 
         assertThat(allKeys).containsExactly('aProperty', 'include', 'a', 'api.key', 'negative', 'string', 'double', 'foo', 'another_PROPERTY', 'positive', 'int')
+    }
+
+    @Test
+    void shouldLogWarningMessageWhenIncludeProvidedInPropertiesFile() {
+        Entries entries = entriesFactory.from(MORE_PROPERTIES)
+        entries['a'].value
+
+        assertThat(warningLog).contains('This feature is deprecated and will be removed in an upcoming release, please use or() operator instead.')
+    }
+
+    private String getWarningLog() {
+        ArgumentCaptor<String> logCaptor = ArgumentCaptor.forClass(String)
+        verify(logger).warn(logCaptor.capture())
+        logCaptor.value
     }
 
     private static File resourceFile(String file) {

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactoryTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactoryTest.groovy
@@ -19,9 +19,8 @@ import static org.mockito.Mockito.verify
 @RunWith(MockitoJUnitRunner)
 class DefaultEntriesFactoryTest {
 
-
     private static final File MORE_PROPERTIES = resourceFile('more.properties')
-    public static final File NOT_THERE_PROPERTIES = new File('notThere.properties')
+    private static final File NOT_THERE_PROPERTIES = new File('notThere.properties')
 
     @Mock private Logger logger
     private ExceptionFactory exceptionFactory

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactoryTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactoryTest.groovy
@@ -1,0 +1,95 @@
+package com.novoda.buildproperties.internal
+
+import com.google.common.io.Resources
+import com.novoda.buildproperties.Entries
+import com.novoda.buildproperties.Entry
+import com.novoda.buildproperties.ExceptionFactory
+import org.gradle.api.logging.Logger
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+
+import static com.novoda.buildproperties.test.ExtendedTruth.assertThat
+import static org.junit.Assert.fail
+
+class DefaultEntriesFactoryTest {
+
+
+    private static final File MORE_PROPERTIES = resourceFile('more.properties')
+    public static final File NOT_THERE_PROPERTIES = new File('notThere.properties')
+
+    @Mock private Logger logger
+    private ExceptionFactory exceptionFactory
+    private ConsoleRenderer consoleRenderer
+
+    private DefaultEntriesFactory entriesFactory
+
+    @Before
+    void setUp() {
+        consoleRenderer = new ConsoleRenderer()
+        exceptionFactory = new DefaultExceptionFactory('foo', consoleRenderer)
+        entriesFactory = new DefaultEntriesFactory(logger, exceptionFactory)
+    }
+
+    @Test
+    void shouldNotThrowExceptionWhenCreatingEntriesFromNonExistentPropertiesFile() {
+        Entries entries = entriesFactory.from(NOT_THERE_PROPERTIES)
+    }
+
+    @Test
+    void shouldNotThrowExceptionWhenAccessingEntryFromNonExistentPropertiesFile() {
+        Entries entries = entriesFactory.from(NOT_THERE_PROPERTIES)
+
+        Entry entry = entries['x']
+    }
+
+    @Test
+    void shouldThrowExceptionWhenEvaluatingEntryFromNonExistentPropertiesFile() {
+        Entries entries = entriesFactory.from(NOT_THERE_PROPERTIES)
+
+        try {
+            entries['x'].string
+            fail('Exception not thrown')
+        } catch (Exception e) {
+            assertThat(e.getMessage()).contains('notThere.properties does not exist.')
+        }
+    }
+
+    @Test
+    void shouldProvideSpecifiedErrorMessageWhenAccessingEntryFromNonExistentPropertiesFile() {
+        def additionalMessage = 'This file should contain the following properties:\n- foo\n- bar'
+        exceptionFactory.additionalMessage = additionalMessage
+        Entries entries = entriesFactory.from(NOT_THERE_PROPERTIES)
+
+        try {
+            entries['x'].string
+            fail('Exception not thrown')
+        } catch (Exception e) {
+            String message = e.getMessage()
+            assertThat(message).contains('notThere.properties does not exist.')
+            assertThat(message).contains(consoleRenderer.indent(additionalMessage, "* buildProperties.foo: "))
+        }
+    }
+
+    @Test
+    void shouldRecursivelyIncludeValuesFromSpecifiedFilesWhenIncludeProvided() {
+        Entries entries = entriesFactory.from(MORE_PROPERTIES)
+
+        def allValues = entries.asMap().values()*.string
+
+        assertThat(allValues).containsExactly('qwerty', 'including.properties', 'android', '?????', 'false', 'hello world', '0.001', 'bar', 'asdfg', 'true', '123456')
+    }
+
+    @Test
+    void shouldRecursivelyIncludeKeysFromSpecifiedFilesWhenIncludeProvided() {
+        Entries entries = entriesFactory.from(MORE_PROPERTIES)
+
+        def allKeys = entries.keys.toSet()
+
+        assertThat(allKeys).containsExactly('aProperty', 'include', 'a', 'api.key', 'negative', 'string', 'double', 'foo', 'another_PROPERTY', 'positive', 'int')
+    }
+
+    private static File resourceFile(String file) {
+        new File(Resources.getResource(file).toURI())
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
@@ -116,11 +116,9 @@ class FilePropertiesEntriesTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenAccessingPropertyFromNonExistentPropertiesFile() {
-        entries = FilePropertiesEntries.create(NOT_THERE_PROPERTIES, exceptionFactory)
-
+    void shouldThrowExceptionWhenCreatingEntriesFromNonExistentPropertiesFile() {
         try {
-            entries['any'].string
+            entries = FilePropertiesEntries.create(NOT_THERE_PROPERTIES, exceptionFactory)
             fail('Exception not thrown')
         } catch (Exception e) {
             assertThat(e.getMessage()).contains('notThere.properties does not exist.')
@@ -128,14 +126,13 @@ class FilePropertiesEntriesTest {
     }
 
     @Test
-    void shouldProvideSpecifiedErrorMessageWhenAccessingPropertyFromNonExistentPropertiesFile() {
+    void shouldProvideSpecifiedErrorMessageWhenCreatingEntriesFromNonExistentPropertiesFile() {
         def additionalMessage = 'This file should contain the following properties:\n- foo\n- bar'
         def consoleRenderer = new ConsoleRenderer()
         exceptionFactory.additionalMessage = additionalMessage
-        entries = FilePropertiesEntries.create(NOT_THERE_PROPERTIES, exceptionFactory)
 
         try {
-            entries['any'].string
+            entries = FilePropertiesEntries.create(NOT_THERE_PROPERTIES, exceptionFactory)
             fail('Exception not thrown')
         } catch (Exception e) {
             String message = e.getMessage()

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
@@ -11,6 +11,9 @@ class FilePropertiesEntriesTest {
 
     private static final File ANY_PROPERTIES = resourceFile('any.properties')
     private static final File NOT_THERE_PROPERTIES = new File('notThere.properties')
+    private static final File MORE_PROPERTIES = resourceFile('more.properties')
+    private static final File INCLUDING_PROPERTIES = resourceFile('including.properties')
+
     private DefaultExceptionFactory exceptionFactory
     private AdditionalMessageProvider additionalMessageProvider
 
@@ -104,8 +107,8 @@ class FilePropertiesEntriesTest {
 
     @Test
     void shouldRecursivelyIncludePropertiesFromSpecifiedFilesWhenIncludeProvided() {
-        def moreEntries = FilePropertiesEntries.create(resourceFile('more.properties'), exceptionFactory)
-        def includingEntries = FilePropertiesEntries.create(resourceFile('including.properties'), exceptionFactory)
+        def moreEntries = FilePropertiesEntries.create(MORE_PROPERTIES, exceptionFactory)
+        def includingEntries = FilePropertiesEntries.create(INCLUDING_PROPERTIES, exceptionFactory)
 
         entries.keys.each { String key ->
             assertThat(moreEntries[key].string).isEqualTo(entries[key].string)
@@ -163,6 +166,13 @@ class FilePropertiesEntriesTest {
                 '0.001',
                 'hello world'
         )
+    }
+
+    @Test
+    void shouldIterateOverAllKeysFromIncludedFiles() {
+        def entries = FilePropertiesEntries.create(MORE_PROPERTIES, exceptionFactory)
+
+        assertThat(Collections.list(entries.keys)).containsExactly('aProperty', 'include', 'a', 'api.key', 'negative', 'string', 'double', 'foo', 'another_PROPERTY', 'positive', 'int')
     }
 
     private static File resourceFile(String file) {

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/FilePropertiesEntriesTest.groovy
@@ -11,8 +11,6 @@ class FilePropertiesEntriesTest {
 
     private static final File ANY_PROPERTIES = resourceFile('any.properties')
     private static final File NOT_THERE_PROPERTIES = new File('notThere.properties')
-    private static final File MORE_PROPERTIES = resourceFile('more.properties')
-    private static final File INCLUDING_PROPERTIES = resourceFile('including.properties')
 
     private DefaultExceptionFactory exceptionFactory
     private AdditionalMessageProvider additionalMessageProvider
@@ -106,19 +104,6 @@ class FilePropertiesEntriesTest {
     }
 
     @Test
-    void shouldRecursivelyIncludePropertiesFromSpecifiedFilesWhenIncludeProvided() {
-        def moreEntries = FilePropertiesEntries.create(MORE_PROPERTIES, exceptionFactory)
-        def includingEntries = FilePropertiesEntries.create(INCLUDING_PROPERTIES, exceptionFactory)
-
-        entries.keys.each { String key ->
-            assertThat(moreEntries[key].string).isEqualTo(entries[key].string)
-        }
-        assertThat(moreEntries['foo'].string).isEqualTo(includingEntries['foo'].string)
-        assertThat(moreEntries['a'].string).isEqualTo('android')
-        assertThat(includingEntries['a'].string).isEqualTo('apple')
-    }
-
-    @Test
     void shouldThrowExceptionWhenCreatingEntriesFromNonExistentPropertiesFile() {
         try {
             entries = FilePropertiesEntries.create(NOT_THERE_PROPERTIES, exceptionFactory)
@@ -166,13 +151,6 @@ class FilePropertiesEntriesTest {
                 '0.001',
                 'hello world'
         )
-    }
-
-    @Test
-    void shouldIterateOverAllKeysFromIncludedFiles() {
-        def entries = FilePropertiesEntries.create(MORE_PROPERTIES, exceptionFactory)
-
-        assertThat(Collections.list(entries.keys)).containsExactly('aProperty', 'include', 'a', 'api.key', 'negative', 'string', 'double', 'foo', 'another_PROPERTY', 'positive', 'int')
     }
 
     private static File resourceFile(String file) {


### PR DESCRIPTION
### Scope of the PR
Follow-up PR to improve/rearchitect the fallback support for properties files. When using a properties file we could specify an `include` value pointing to which properties file to use as fallback.This way we could for instance share a common set of properties across different properties sets via single file, while allowing to override and add properties as needed. 

### Considerations/Implementation Details
The `include` functionality has been pulled out `FilePropertiesEntries` into `DefaultEntriesFactory` where we would instead build an `EntriesChain` to achieve the same. In order to discourage the use of this functionality without breaking things a warning log has been added in order to notify the users of the new option.