### PR TITLE
[PT-631] Expose contains and add project properties entries

### DIFF
--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -63,6 +63,10 @@ class BuildProperties {
         newChain(buildProperties.entries)
     }
 
+    EntriesChain using(Project project) {
+        newChain(project)
+    }
+
     private EntriesChain newChain(def source) {
         chain = new EntriesChain(factory, source)
         return chain

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -35,6 +35,10 @@ class BuildProperties {
         chain.getAt(key)
     }
 
+    Map<String, Entry> asMap() {
+        entries.asMap()
+    }
+
     boolean contains(String key) {
         chain.contains(key)
     }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -35,8 +35,8 @@ class BuildProperties {
         chain.getAt(key)
     }
 
-    Map<String, Entry> asMap() {
-        entries.asMap()
+    boolean contains(String key) {
+        chain.contains(key)
     }
 
     void setDescription(String description) {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactory.groovy
@@ -5,6 +5,7 @@ import com.novoda.buildproperties.Entries
 import com.novoda.buildproperties.EntriesChain
 import com.novoda.buildproperties.ExceptionFactory
 import org.gradle.api.GradleException
+import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 
 class DefaultEntriesFactory implements Entries.Factory {
@@ -28,6 +29,8 @@ class DefaultEntriesFactory implements Entries.Factory {
                 return new MapEntries(source as Map<String, Object>, exceptionFactory)
             case File:
                 return new LazyEntries({ newFilePropertiesEntries(source as File) })
+            case Project:
+                return ProjectPropertiesEntries.from(source as Project, exceptionFactory)
             default:
                 throw new GradleException("Unsupported type of source (${source.class})")
         }

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/ProjectPropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/ProjectPropertiesEntries.groovy
@@ -1,0 +1,43 @@
+package com.novoda.buildproperties.internal
+
+import com.novoda.buildproperties.Entries
+import com.novoda.buildproperties.Entry
+import com.novoda.buildproperties.ExceptionFactory
+import org.gradle.api.Project
+
+class ProjectPropertiesEntries extends Entries {
+
+    private final Project project
+    private final ExceptionFactory exceptionFactory
+
+    static ProjectPropertiesEntries from(Project project, ExceptionFactory exceptionFactory) {
+        return new ProjectPropertiesEntries(project, exceptionFactory)
+    }
+
+    private ProjectPropertiesEntries(Project project, ExceptionFactory exceptionFactory) {
+        this.project = project
+        this.exceptionFactory = exceptionFactory
+    }
+
+    @Override
+    boolean contains(String key) {
+        return project.hasProperty(key)
+    }
+
+    @Override
+    Entry getAt(String key) {
+        return new Entry(key, {
+            if (project.hasProperty(key)) {
+                return project.property(key)
+            }
+            throw exceptionFactory.propertyNotFound(key)
+        })
+    }
+
+
+
+    @Override
+    Enumeration<String> getKeys() {
+        return Collections.enumeration(project.properties.keySet())
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/buildproperties/internal/ProjectPropertiesEntries.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/internal/ProjectPropertiesEntries.groovy
@@ -35,7 +35,6 @@ class ProjectPropertiesEntries extends Entries {
     }
 
 
-
     @Override
     Enumeration<String> getKeys() {
         return Collections.enumeration(project.properties.keySet())

--- a/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
@@ -166,6 +166,30 @@ class BuildPropertiesTest {
         assertThat(project.buildProperties.chain['f']).hasValue('value_f')
     }
 
+    @Test
+    public void shouldReturnTrueWhenBuildPropertiesContainKey() {
+        environment.set('a', 'value_a')
+
+        project.buildProperties {
+            env {
+                using System.getenv()
+            }
+        }
+
+        assertThat(project.buildProperties.env.contains('a')).isTrue()
+    }
+
+    @Test
+    public void shouldReturnFalseWhenBuildPropertiesDoNotContainKey() {
+        project.buildProperties {
+            env {
+                using System.getenv()
+            }
+        }
+
+        assertThat(project.buildProperties.env.contains('unknown')).isFalse()
+    }
+
     private File newPropertiesFile(String fileName, String fileContent) {
         File propertiesFile = temp.newFile(fileName)
         propertiesFile.text = fileContent

--- a/plugin/src/test/groovy/com/novoda/buildproperties/ProjectPropertiesEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/ProjectPropertiesEntriesTest.groovy
@@ -29,7 +29,7 @@ class ProjectPropertiesEntriesTest {
         entries = ProjectPropertiesEntries.from(project, new DefaultExceptionFactory('foo'))
     }
 
-    @Test()
+    @Test
     public void shouldThrowExceptionWhenPropertyIsNotSet() {
         try {
             entries['notThere'].string

--- a/plugin/src/test/groovy/com/novoda/buildproperties/ProjectPropertiesEntriesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/ProjectPropertiesEntriesTest.groovy
@@ -1,0 +1,48 @@
+package com.novoda.buildproperties
+
+import com.novoda.buildproperties.internal.DefaultExceptionFactory
+import com.novoda.buildproperties.internal.ProjectPropertiesEntries
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import static com.novoda.buildproperties.test.ExtendedTruth.assertThat
+import static org.junit.Assert.fail
+
+class ProjectPropertiesEntriesTest {
+
+    @Rule
+    public final TemporaryFolder temp = new TemporaryFolder()
+
+    private Project project
+    private Entries entries
+
+    @Before
+    public void setUp() {
+        project = ProjectBuilder.builder()
+                .withProjectDir(temp.newFolder())
+                .build()
+
+        entries = ProjectPropertiesEntries.from(project, new DefaultExceptionFactory('foo'))
+    }
+
+    @Test()
+    public void shouldThrowExceptionWhenPropertyIsNotSet() {
+        try {
+            entries['notThere'].string
+            fail('Exception expected')
+        } catch (Exception e) {
+            assertThat(e.getMessage()).contains("Unable to find value for key 'notThere'")
+        }
+    }
+
+    @Test
+    public void shouldResolveProjectPropertyThroughBuildProperties() {
+        project.ext.key = 'value'
+
+        assertThat(entries['key'].string).isEqualTo('value')
+    }
+}

--- a/plugin/src/test/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactoryTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/internal/DefaultEntriesFactoryTest.groovy
@@ -5,6 +5,7 @@ import com.novoda.buildproperties.Entries
 import com.novoda.buildproperties.Entry
 import com.novoda.buildproperties.ExceptionFactory
 import org.gradle.api.logging.Logger
+import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -99,6 +100,15 @@ class DefaultEntriesFactoryTest {
         entries['a'].value
 
         assertThat(warningLog).contains('This feature is deprecated and will be removed in an upcoming release, please use or() operator instead.')
+    }
+
+    @Test
+    public void shouldResolveKeysFromProjectPropertiesEntries() {
+        def project = ProjectBuilder.builder().build()
+
+        Entries entries = entriesFactory.from(project)
+
+        assertThat(entries).isInstanceOf(ProjectPropertiesEntries.class)
     }
 
     private String getWarningLog() {

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -29,7 +29,7 @@ buildProperties {
         using System.getenv()
     }
     cli {
-        using project.properties
+        using project
     }
 }
 


### PR DESCRIPTION
### Description
This fixes https://github.com/novoda/gradle-build-properties-plugin/issues/47 to expose a more simple api to check whether the build properties contain a certain key.

Additionally it adds `ProjectPropertiesEntries` which allows the user to consume project properties through the build properties.

### Considerations
- since we're gonna rework the documentation soon I didn't document these changes

### Testing
- added tests to verify that `BuildProperties.contains` returns true or false depending on if a certain key existists
- added tests to verify `ProjectPropertiesEntries` resolve entries through project properties