### PR TITLE
[PT-629] Restructure documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Add a `buildProperties` configuration to your build script listing
 all the properties files you intend to reference later on:
 ```gradle
 buildProperties {
-    
     secrets {
         using project.file('secrets.properties')
     }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ String label = buildProperties.secrets['d'].string
 ```
 
 It is important to note that values are lazy loaded too. Trying to access the value of a specific property 
-could generate an exception if the key is missing in the provided properties file, eg:
+could generate an exception if the key is missing in the provided properties file, e.g.:
 ```
 FAILURE: Build failed with an exception.
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ buildProperties {
     }
 }
 ```
-where `secrets.properties` is a properties file, containing key/value pairs, that can now be referenced
-in the build script as `buildProperties.secrets`:
+where `secrets.properties` is a properties file containing key/value pairs:
+```gradle
+secret_key=12345
+foo=bar
+```
+that can now be referenced in the build script as `buildProperties.secrets`:
 ```gradle
 boolean enabled = buildProperties.secrets['a'].boolean
 int count = buildProperties.secrets['b'].int

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ properties in your build scripts, for security reasons and in order to increase 
 common practice to provide these properties from external sources. 
 
 This plugin aims to provide a simple way to:
-- consume properties from external and internal sources like cli, system properties, files etc.
+- consume properties from external and internal sources like project properties, system properties, files etc.
 - define a custom source for properties
 - configure Android build with external properties 
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 # gradle-build-properties-plugin
 [![](https://ci.novoda.com/buildStatus/icon?job=gradle-build-properties-plugin)](https://ci.novoda.com/job/gradle-build-properties-plugin/lastSuccessfulBuild/console) [![](https://img.shields.io/badge/License-Apache%202.0-lightgrey.svg)](LICENSE.txt) [![Bintray](https://api.bintray.com/packages/novoda/maven/gradle-build-properties-plugin/images/download.svg) ](https://bintray.com/novoda/maven/gradle-build-properties-plugin/_latestVersion)
 
-External properties files support for your build scripts.
+External properties support for your build scripts.
 
 ## Description
 
-Sometimes it's necessary to retrieve some information from a properties
-file that is not checked in as part of your repo for security reasons
-(keys, credentials, passwords, etc). Such properties need to end up in
-your application `BuildConfig` or in some resource file.
+Gradle builds are highly configurable through various properties. Rather than hardcoding these
+properties in your build scripts, for security reasons and in order to increase modularity, it's a
+common practice to provide these properties from external sources. 
 
 This plugin aims to provide a simple way to:
-- define handles to a properties file in your build script
-- generate fields in your `BuildConfig` with values from a properties file
-- generate resources with values from a properties file
+- consume properties from external and internal sources like cli, system properties, files etc.
+- define a custom source for properties
+- configure Android build with external properties 
 
 
 ## Adding to your project

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gradle-build-properties-plugin
 [![](https://ci.novoda.com/buildStatus/icon?job=gradle-build-properties-plugin)](https://ci.novoda.com/job/gradle-build-properties-plugin/lastSuccessfulBuild/console) [![](https://img.shields.io/badge/License-Apache%202.0-lightgrey.svg)](LICENSE.txt) [![Bintray](https://api.bintray.com/packages/novoda/maven/gradle-build-properties-plugin/images/download.svg) ](https://bintray.com/novoda/maven/gradle-build-properties-plugin/_latestVersion)
 
-External properties support for your build scripts.
+External properties support for your gradle builds.
 
 ## Description
 
@@ -13,7 +13,6 @@ This plugin aims to provide a simple way to:
 - consume properties from external and internal sources like cli, system properties, files etc.
 - define a custom source for properties
 - configure Android build with external properties 
-
 
 ## Adding to your project
 
@@ -40,8 +39,9 @@ Add a `buildProperties` configuration to your build script listing
 all the properties files you intend to reference later on:
 ```gradle
 buildProperties {
+    
     secrets {
-        file project.file('secrets.properties')
+        using project.file('secrets.properties')
     }
 }
 ```
@@ -60,8 +60,7 @@ The value of an `Entry` can be retrieved via one of its typed accessors:
 - `String label = buildProperties.secrets['x'].string`
 
 It is important to note that values are lazy loaded too (via the internal closure provided in `Entry`).
-Trying to access the value of a specific property could generate an exception
-if the key is missing in the provided properties file, eg:
+Trying to access the value of a specific property could generate an exception if the key is missing in the provided properties file, eg:
 ```
 FAILURE: Build failed with an exception.
 
@@ -71,138 +70,6 @@ A problem occurred configuring project ':app'.
 
 ```
 
-## Features
+## Advanced usage
 
-#### Fallback support
-If a property cannot be found an exception is thrown, it's possible to provide a fallback
-value for a given `Entry` via the `or()` operator, defined as:
-
-| | Example |
-|----|----|
-|another `Entry` | `buildProperties.secrets['notThere'].or(buildProperties.secrets['fallback'])` |
-|a `Closure` | `buildProperties.secrets['notThere'].or({ Math.random() })` |
-|a value | `buildProperties.secrets['notThere'].or('fallback')` |
-
-If the whole fallback chain evaluation fails then a `CompositeException` is thrown listing all
-the causes in the chain, eg:
-
-```
-A problem occurred while evaluating entry:
-- exception message 1
-- exception message 2
-- exception message 3
-
-```
-
-#### Properties inheritance
-It might be useful to have properties files that can recursively include
-other properties files (specified via an `include` property).
-Inherited properties can be overridden by the including set, just redefine
-the property in the file and its value will be used instead of the one
-from the included set.
-
-For example, given a generic properties file `config.properties`:
-
-```properties
-foo=bar
-aKey=aValue
-```
-
-you can override values and add additional ones in another properties file `debug.properties`:
-
-```properties
-include=/path/to/config.properties
-aNewKey=aNewValue
-aKey=overriddenPreviousValue
-```
-
-Then in your `build.gradle`:
-
-```gradle
-buildProperties {
-    secrets {
-        file rootProject.file('debug.properties')
-    }
-}
-
-...
-
-android {
-    ...
-
-    defaultConfig {
-        ...
-        buildConfigString 'FOO', buildProperties.secrets['foo'] // bar
-        buildConfigString 'A_KEY', buildProperties.secrets['aKey'] // overriddenPreviousValue
-        buildConfigString 'A_NEW_KEY', buildProperties.secrets['aNewKey'] // aNewValue
-        ...
-    }
-}
-```
-
-#### More on loading properties
-If the specified file is not found an exception is thrown at build time as soon as one of its properties is evaluated.
-You can specify a custom error message to provide the user with more information, eg:
-```gradle
-buildProperties {
-    secrets {
-        file rootProject.file('secrets.properties'), '''
-           This file should contain the following properties:
-           - fabricApiKey: API key for Fabric
-           - googleMapsApiKey: API key for Google Maps
-        '''
-    }
-}
-```
-
-
-## Android-specific features
-
-When applying the `gradle-build-properties-plugin` to an Android project you get access to an
- additional set of powerful features.
-
-#### 1. Store a property value into your `BuildConfig`
-In any product flavor configuration (or `defaultConfig`) you can use
-`buildConfigString` as follows:
-```gradle
-    defaultConfig {
-        ...
-        buildConfigString 'API_KEY', buildProperties.secrets['apiKey']
-        ...
-    }
-```
-
-#### 2. Store a property value as generated string resource
-In any product flavor configuration (or `defaultConfig`) you can use
-`resValueProperty` as follows:
-
-```gradle
-    defaultConfig {
-        ...
-        resValueProperty 'api_key', buildProperties.secrets['apiKey']
-        ...
-    }
-```
-
-#### 3. Typed `buildConfigField` / `resValue`
-The plugin enhances the `buildConfigField` and `resValue` facilities to
-enforce types. To generate a string field in your `BuildConfig` you used to write:
-```gradle
-buildConfigField 'String', 'LOL', '\"sometimes the picture take\"'
-```
-but now you can instead write:
-```gradle
-buildConfigString 'LOL', 'sometimes the picture take'
-```
-The full list of new typed facilities is as follows:
-
-| | Example |
-|----|----|
-|`buildConfigBoolean` | `buildConfigBoolean 'TEST_BOOLEAN', false`|
-|`buildConfigInt` | `buildConfigInt 'TEST_INT', 42`|
-|`buildConfigLong` | `buildConfigLong 'TEST_LONG', System.currentTimeMillis()`|
-|`buildConfigDouble` | `buildConfigDouble 'TEST_DOUBLE', Math.PI`|
-|`buildConfigString` | `buildConfigString 'TEST_STRING', 'whateva'`|
-|`resValueInt`| `resValueInt 'debug_test_int', 100`|
-|`resValueBoolean` | `resValueBoolean 'debug_test_bool', true`|
-|`resValueString` | `resValueString 'debug_test_string', 'dunno bro...'`|
+For more advanced configurations, please refer to the [advanced usage](docs/advanced-usage.md).

--- a/README.md
+++ b/README.md
@@ -45,22 +45,17 @@ buildProperties {
     }
 }
 ```
-where `secrets.properties` is a properties file that can now be referenced
-in the build script as `buildProperties.secrets`. Entries in such file can be
-accessed via the `getAt` operator:
+where `secrets.properties` is a properties file, containing key/value pairs, that can now be referenced
+in the build script as `buildProperties.secrets`:
 ```gradle
-Entry entry = buildProperties.secrets['aProperty']
+boolean enabled = buildProperties.secrets['a'].boolean
+int count = buildProperties.secrets['b'].int
+double rate = buildProperties.secrets['c'].double
+String label = buildProperties.secrets['d'].string
 ```
 
-The value of an `Entry` can be retrieved via one of its typed accessors:
-
-- `boolean enabled = buildProperties.secrets['x'].boolean`
-- `int count = buildProperties.secrets['x'].int`
-- `double rate = buildProperties.secrets['x'].double`
-- `String label = buildProperties.secrets['x'].string`
-
-It is important to note that values are lazy loaded too (via the internal closure provided in `Entry`).
-Trying to access the value of a specific property could generate an exception if the key is missing in the provided properties file, eg:
+It is important to note that values are lazy loaded too. Trying to access the value of a specific property 
+could generate an exception if the key is missing in the provided properties file, eg:
 ```
 FAILURE: Build failed with an exception.
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,16 +1,24 @@
 # Advanced configuration
 
 The plugin supports a number of advanced behaviours. For example, it can be used to consume properties 
-from various external sources, fallbacks can be configured in case a given source doesn't have a certain property, 
-properties can be used in Android builds as `buildConfigField` and `resValue`.    
+from various external sources, fallbacks can be configured in case a given source doesn't have a certain property and 
+properties can be used in Android builds as `buildConfigField` and `resValue`.   
+
+For most features the sample project, which can be found on the [github repo](https://github.com/novoda/gradle-build-properties-plugin/tree/master/sample),
+provides fully working examples.  
 
 ## Table of contents
- * Different property sources 
+ * [Reading properties from different sources](#reading-properties-from-different-sources) 
  * Custom property source
  * Fallback/Chaining mechanism
  * Android build configuration variables
  * Android resource variables
  * Android property backed flavors
+ 
+ 
+## Reading properties from different sources
+
+The plugin comes with built in support for various sources for properties. 
 
 ## Features
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,6 +1,8 @@
 # Advanced configuration
 
-Besides parametrized builds, the plugin supports a couple of advanced usages, especially for Android.
+The plugin supports a number of advanced behaviours. For example, it can be used to consume properties 
+from various external sources, fallbacks can be configured in case a given source doesn't have a certain property, 
+properties can be used in Android builds as `buildConfigField` and `resValue`.    
 
 ## Table of contents
  * Different property sources 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -4,7 +4,7 @@ The plugin supports a number of advanced behaviours. For example, it can be used
 from various external sources, it provides fallbacks for dynamic properties and can be 
 used in Android projects to map build properties to `buildConfigField` and `resValue`.   
 
-For most features examples can be also found on our [github repo](https://github.com/novoda/gradle-build-properties-plugin/tree/master/sample).  
+Examples for most features can also be found on our [github repo](https://github.com/novoda/gradle-build-properties-plugin/tree/master/sample).  
 
 ## Table of contents
  * [Read properties from different sources](#reading-properties-from-different-sources) 
@@ -93,7 +93,7 @@ A fallback value for a given `Entry` via the `or()` operator can be defined as:
 |a value | `buildProperties.secrets['notThere'].or('fallback')` |
 
 If the whole fallback chain evaluation fails then a `CompositeException` is thrown listing all
-the causes in the chain, eg:
+the causes in the chain, e.g.:
 
 ```
 A problem occurred while evaluating entry:

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,11 +1,10 @@
 # Advanced configuration
 
 The plugin supports a number of advanced behaviours. For example, it can be used to consume properties 
-from various external sources, fallbacks can be configured in case a given source doesn't have a certain property and 
-properties can be used in Android builds as `buildConfigField` and `resValue`.   
+from various external sources, it provides fallbacks for dynamic properties and can be 
+used in Android projects to map build properties to `buildConfigField` and `resValue`.   
 
-For most features the sample project, which can be found on the [github repo](https://github.com/novoda/gradle-build-properties-plugin/tree/master/sample),
-provides fully working examples.  
+For most features examples can be also found on our [github repo](https://github.com/novoda/gradle-build-properties-plugin/tree/master/sample).  
 
 ## Table of contents
  * [Read properties from different sources](#reading-properties-from-different-sources) 
@@ -16,7 +15,7 @@ provides fully working examples.
  
 ## Reading properties from different sources
 
-The plugin comes with built in support for various sources for properties, that can be configured within the 
+The plugin comes with built in support for various sources for properties that can be configured within the 
 `buildProperties` closure.
 
 ### Files
@@ -43,9 +42,13 @@ cli {
 }
 ```
 
-Project properties can be either either passed via the command line or the build script itself:
+Project properties can be either either passed via the command line:
 
-`gradlew build -Papi_key=12345`
+```gradle
+gradlew build -Papi_key=12345
+```
+
+or via the build script itself:
 
 ```gradle
 ext {
@@ -65,8 +68,8 @@ env {
 
 ## Define custom property source
 
-Besides the built in sources for properties, the plugin also provides an API to create custom sources.
-Custom sources need to extend the `Entries` and can be provided via `BuildProperties.entries(Entries entries)`. For example, 
+Besides the built-in sources for properties, the plugin also provides an API to create custom ones.
+These need to extend the `Entries` and can be provided via `BuildProperties.entries(Entries entries)`. For example, 
 a custom implementation could consume properties from a web resource.
 
 ```gradle
@@ -77,7 +80,7 @@ api {
  
 
 ## Fallback support
-If a property cannot be found an exception is thrown, it's possible to provide a fallback.
+If a property cannot be found it's possible to provide a fallback.
 
 ### Fallback Entry
 
@@ -112,8 +115,7 @@ files {
 
 ## Map properties to Android Gradle plugin
 
-Using the plugin, properties can be mapped as `buildConfigField` and `resValue` to the Gradle Android plugin.
-Besides that it enhances these facilities by enforcing types.
+Using the plugin, properties can be mapped as `buildConfigField` and `resValue` to the Android Gradle plugin.
 
 ```gradle
 buildProperties {
@@ -130,6 +132,8 @@ android {
         buildConfigString 'CLIENT_SECRET', buildProperties.api['api_client_secret']
         ...
 ```
+
+Besides that it enhances these facilities by enforcing types. 
 
 To generate a string field in your BuildConfig you used to write:
 
@@ -159,7 +163,7 @@ The full list of new typed facilities is as follows:
 
 ## Define Android product flavors using properties
 
-Using the plugin properties can be also injected into other gradle plugin extensions. 
+Using the plugin, properties can be also injected into other gradle plugin extensions. 
 
 For example, Android `productFlavors` can be easily configured by first creating a method that configures a product flavor from 
 given properties:
@@ -179,7 +183,7 @@ productFlavors.all { flavor ->
 }
 ```
 
-And then using it to configure the `productFlavors`: 
+and then by calling it: 
 
 ```gradle
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,0 +1,147 @@
+# Advanced configuration
+
+Besides parametrized builds, the plugin supports a couple of advanced usages, especially for Android.
+
+## Table of contents
+ * Different property sources 
+ * Custom property source
+ * Fallback/Chaining mechanism
+ * Android build configuration variables
+ * Android resource variables
+ * Android property backed flavors
+
+## Features
+
+#### Fallback support
+If a property cannot be found an exception is thrown, it's possible to provide a fallback
+value for a given `Entry` via the `or()` operator, defined as:
+
+| | Example |
+|----|----|
+|another `Entry` | `buildProperties.secrets['notThere'].or(buildProperties.secrets['fallback'])` |
+|a `Closure` | `buildProperties.secrets['notThere'].or({ Math.random() })` |
+|a value | `buildProperties.secrets['notThere'].or('fallback')` |
+
+If the whole fallback chain evaluation fails then a `CompositeException` is thrown listing all
+the causes in the chain, eg:
+
+```
+A problem occurred while evaluating entry:
+- exception message 1
+- exception message 2
+- exception message 3
+
+```
+
+#### Properties inheritance
+It might be useful to have properties files that can recursively include
+other properties files (specified via an `include` property).
+Inherited properties can be overridden by the including set, just redefine
+the property in the file and its value will be used instead of the one
+from the included set.
+
+For example, given a generic properties file `config.properties`:
+
+```properties
+foo=bar
+aKey=aValue
+```
+
+you can override values and add additional ones in another properties file `debug.properties`:
+
+```properties
+include=/path/to/config.properties
+aNewKey=aNewValue
+aKey=overriddenPreviousValue
+```
+
+Then in your `build.gradle`:
+
+```gradle
+buildProperties {
+    secrets {
+        file rootProject.file('debug.properties')
+    }
+}
+
+...
+
+android {
+    ...
+
+    defaultConfig {
+        ...
+        buildConfigString 'FOO', buildProperties.secrets['foo'] // bar
+        buildConfigString 'A_KEY', buildProperties.secrets['aKey'] // overriddenPreviousValue
+        buildConfigString 'A_NEW_KEY', buildProperties.secrets['aNewKey'] // aNewValue
+        ...
+    }
+}
+```
+
+#### More on loading properties
+If the specified file is not found an exception is thrown at build time as soon as one of its properties is evaluated.
+You can specify a custom error message to provide the user with more information, eg:
+```gradle
+buildProperties {
+    secrets {
+        file rootProject.file('secrets.properties'), '''
+           This file should contain the following properties:
+           - fabricApiKey: API key for Fabric
+           - googleMapsApiKey: API key for Google Maps
+        '''
+    }
+}
+```
+
+
+## Android-specific features
+
+When applying the `gradle-build-properties-plugin` to an Android project you get access to an
+ additional set of powerful features.
+
+#### 1. Store a property value into your `BuildConfig`
+In any product flavor configuration (or `defaultConfig`) you can use
+`buildConfigString` as follows:
+```gradle
+    defaultConfig {
+        ...
+        buildConfigString 'API_KEY', buildProperties.secrets['apiKey']
+        ...
+    }
+```
+
+#### 2. Store a property value as generated string resource
+In any product flavor configuration (or `defaultConfig`) you can use
+`resValueProperty` as follows:
+
+```gradle
+    defaultConfig {
+        ...
+        resValueProperty 'api_key', buildProperties.secrets['apiKey']
+        ...
+    }
+```
+
+#### 3. Typed `buildConfigField` / `resValue`
+The plugin enhances the `buildConfigField` and `resValue` facilities to
+enforce types. To generate a string field in your `BuildConfig` you used to write:
+```gradle
+buildConfigField 'String', 'LOL', '\"sometimes the picture take\"'
+```
+but now you can instead write:
+```gradle
+buildConfigString 'LOL', 'sometimes the picture take'
+```
+The full list of new typed facilities is as follows:
+
+| | Example |
+|----|----|
+|`buildConfigBoolean` | `buildConfigBoolean 'TEST_BOOLEAN', false`|
+|`buildConfigInt` | `buildConfigInt 'TEST_INT', 42`|
+|`buildConfigLong` | `buildConfigLong 'TEST_LONG', System.currentTimeMillis()`|
+|`buildConfigDouble` | `buildConfigDouble 'TEST_DOUBLE', Math.PI`|
+|`buildConfigString` | `buildConfigString 'TEST_STRING', 'whateva'`|
+|`resValueInt`| `resValueInt 'debug_test_int', 100`|
+|`resValueBoolean` | `resValueBoolean 'debug_test_bool', true`|
+|`resValueString` | `resValueString 'debug_test_string', 'dunno bro...'`|

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -120,7 +120,7 @@ Using the plugin, properties can be mapped as `buildConfigField` and `resValue` 
 ```gradle
 buildProperties {
     api {
-            file project.file('../properties/api_secrets.properties')
+            using project.file('../properties/api_secrets.properties')
     }
 }
 


### PR DESCRIPTION
### Description
Scope of this PR is to add documentation for missing features, to separate advanced from simple usages and to change the wording to introduce the plugin as tool to parametrise builds rather than focus on android related features.

### Considerations
- advanced use cases have been extracted to `advanced-usage.md`