### PR TITLE
Bump version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.novoda:gradle-build-properties-plugin:0.3'
+    classpath 'com.novoda:gradle-build-properties-plugin:0.3.9'
   }
 }
 ```


### PR DESCRIPTION
The latest available version is 0.3.9 but the readme is stuck at 0.3. This updates it.