### PR TITLE
[PT-634] Prepare v0.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.novoda:gradle-build-properties-plugin:0.4.0'
+    classpath 'com.novoda:gradle-build-properties-plugin:0.4'
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ This plugin aims to provide a simple way to:
 
 ## Adding to your project
 
-The plugin is deployed to Bintray's JCenter. Ensure it's correctly defined
-as a dependency for your build script:
+Apply the plugin from jCenter as a classpath dependency:
 
 ```gradle
 buildscript {
@@ -31,10 +30,16 @@ buildscript {
     classpath 'com.novoda:gradle-build-properties-plugin:0.4.0'
   }
 }
-```
-Then apply the plugin in your build script via:
-```gradle
+
 apply plugin: 'com.novoda.build-properties'
+```
+
+or from the Gradle Plugins Repository:
+
+```gradle
+plugins {
+    id 'com.novoda.build-properties' version '0.4'
+}
 ```
 
 ## Simple usage

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.novoda:gradle-build-properties-plugin:0.3.9'
+    classpath 'com.novoda:gradle-build-properties-plugin:0.4.0'
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -74,3 +74,5 @@ A problem occurred configuring project ':app'.
 ## Advanced usage
 
 For more advanced configurations, please refer to the [advanced usage](docs/advanced-usage.md).
+
+The latest Groovydoc can be found [here](https://novoda.github.io/gradle-build-properties-plugin/docs/0.4/).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+# Releasing
+
+1. Bump version code in `publish.gradle`.
+1. Update examples in `README.md` to use the latest version.
+1. Create an entry in `CHANGELOG.md` containing the changes in that release. This entry needs to follow a certain pattern which can be found in `publish.gradle`. The changelog can be verified by executing the `printChangelog` task.
+1. Create a pull request to `develop` containing the above mentioned changes.
+1. Merge `develop` into `master`.
+1. Execute the [build job](https://ci.novoda.com/job/gradle-build-properties-plugin/) manually with `BINTRAY_DRY_RUN=false`.
+1. After the release is successful do a manual [github release](https://github.com/novoda/gradle-build-properties-plugin/releases) with the newly created tag. 
+
+This releases the plugin to [bintray](https://bintray.com/novoda/maven/gradle-build-properties-plugin) and the [Gradle Plugins Repository](https://plugins.gradle.org/plugin/com.novoda.build-properties).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,7 @@
 
 1. Bump version code in `publish.gradle`.
 1. Update examples in `README.md` to use the latest version.
+1. Update link to Groovydoc in `README.md` to use the latest version.
 1. Create an entry in `CHANGELOG.md` containing the changes in that release. This entry needs to follow a certain pattern which can be found in `publish.gradle`. The changelog can be verified by executing the `printChangelog` task.
 1. Create a pull request to `develop` containing the above mentioned changes.
 1. Merge `develop` into `master`.

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -7,7 +7,7 @@ ext {
     websiteUrl = 'https://github.com/novoda/gradle-build-properties-plugin'
 }
 
-version = '0.3'
+version = '0.4'
 String tag = "v$project.version"
 groovydoc.docTitle = 'Build Properties Plugin'
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,8 +1,22 @@
 apply plugin: 'com.novoda.bintray-release'
+
+version = '0.3'
+String tag = "v$project.version"
+
 publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'gradle-build-properties-plugin'
-    publishVersion = '0.3'
+    publishVersion = project.version
     website = 'https://github.com/novoda/gradle-build-properties-plugin'
+}
+
+task publishRelease {
+    description = "Publish release for plugin version: $tag"
+    group = 'release'
+
+    if (project.hasProperty('dryRun') && project['dryRun'] == 'false') {
+        dependsOn bintrayUpload
+    }
+    
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,22 +1,128 @@
+apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'com.novoda.bintray-release'
+apply plugin: 'org.ajoberstar.grgit'
+apply plugin: 'org.ajoberstar.github-pages'
+
+ext {
+    websiteUrl = 'https://github.com/novoda/gradle-build-properties-plugin'
+}
 
 version = '0.3'
 String tag = "v$project.version"
+groovydoc.docTitle = 'Build Properties Plugin'
 
 publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'gradle-build-properties-plugin'
     publishVersion = project.version
-    website = 'https://github.com/novoda/gradle-build-properties-plugin'
+    website = websiteUrl
+}
+
+githubPages {
+    commitMessage = "Deploy groovydoc for release $tag"
+    pages {
+        from groovydoc.destinationDir
+        into "docs/${project.version}"
+    }
+}
+
+pluginBundle {
+    website = websiteUrl
+    vcsUrl = websiteUrl
+    description = 'A Gradle plugin to consume external build properties.'
+    tags = ['java', 'android', 'gradle', 'build properties', 'project properties', "system properties"]
+
+    plugins {
+        gradleBuildPropertiesPlugin {
+            id = 'com.novoda.build-properties'
+            displayName = 'Gradle build properties plugin'
+        }
+    }
+}
+
+task prepareGhCredentials {
+    description = 'Prepare GitHub credentials'
+    group = 'release'
+    doLast {
+        String username = System.getenv()['GITHUB_USERNAME']
+        String password = System.getenv()['GITHUB_TOKEN']
+        System.properties['org.ajoberstar.grgit.auth.username'] = username
+        System.properties['org.ajoberstar.grgit.auth.password'] = password
+    }
+}
+
+prepareGhPages.dependsOn groovydoc
+publishGhPages.dependsOn prepareGhCredentials
+
+task prepareGradlePluginsRepoRelease {
+    doLast {
+        System.properties['gradle.publish.key'] = System.getenv()['GRADLE_PLUGINS_REPO_KEY']
+        System.properties['gradle.publish.secret'] = System.getenv()['GRADLE_PLUGINS_REPO_SECRET']
+    }
+}
+
+task prepareRelease {
+    description = 'Prepare changelog and tag for release'
+    group = 'release'
+    dependsOn prepareGhPages, prepareGhCredentials, prepareGradlePluginsRepoRelease
+    doLast {
+        String changelog = extractChangelog()
+        grgit.tag.add {
+            name = tag
+            message = "Release $tag\n\n$changelog"
+        }
+    }
+}
+
+String extractChangelog() {
+    String fullChangelog = rootProject.file('CHANGELOG.md').text
+    def latestChangelog = (fullChangelog =~ /\[Version ${project.version}.*\n-*([\s\S]*?)\[Version.*\n-*/)
+    if (latestChangelog.size() > 0) {
+        return latestChangelog[0][1].trim()
+    }
+
+    def firstChangelog = (fullChangelog =~ /\[Version ${project.version}.*\n-*([\s\S]*)/)
+    if (firstChangelog.size() > 0) {
+        return firstChangelog[0][1].trim()
+    }
+    throw new GradleException("No changelog found for version $project.version")
+}
+
+task printChangelog {
+    group = 'help'
+    description = "Print the provisional changelog for version $project.version"
+    doLast {
+        println "\nChangelog for version $project.version:\n${extractChangelog()}\n"
+    }
+}
+
+task publishArtifact {
+    description = "Publish artifact for plugin version: $tag"
+    group = 'release'
+    project.afterEvaluate { dependsOn bintrayUpload }
+    mustRunAfter prepareRelease
+}
+
+task publishGroovydoc {
+    description = "Deploy groovydoc for plugin version: $tag"
+    group = 'release'
+    dependsOn publishGhPages
+    mustRunAfter publishArtifact
 }
 
 task publishRelease {
     description = "Publish release for plugin version: $tag"
     group = 'release'
-
     if (project.hasProperty('dryRun') && project['dryRun'] == 'false') {
-        dependsOn bintrayUpload
+        dependsOn prepareRelease, publishArtifact, publishGroovydoc, publishPlugins
+        doLast {
+            grgit.push {
+                tags = true
+            }
+        }
+    } else {
+        dependsOn publishArtifact
     }
-    
 }
+

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -97,10 +97,13 @@ task printChangelog {
     }
 }
 
-task publishArtifact {
-    description = "Publish artifact for plugin version: $tag"
+task publishArtifacts {
+    description = "Publish artifacts for plugin version: $tag"
     group = 'release'
-    project.afterEvaluate { dependsOn bintrayUpload }
+    project.afterEvaluate {
+        dependsOn bintrayUpload
+        dependsOn publishPlugins
+    }
     mustRunAfter prepareRelease
 }
 
@@ -108,21 +111,21 @@ task publishGroovydoc {
     description = "Deploy groovydoc for plugin version: $tag"
     group = 'release'
     dependsOn publishGhPages
-    mustRunAfter publishArtifact
+    mustRunAfter publishArtifacts
 }
 
 task publishRelease {
     description = "Publish release for plugin version: $tag"
     group = 'release'
     if (project.hasProperty('dryRun') && project['dryRun'] == 'false') {
-        dependsOn prepareRelease, publishArtifact, publishGroovydoc, publishPlugins
+        dependsOn prepareRelease, publishArtifacts, publishGroovydoc
         doLast {
             grgit.push {
                 tags = true
             }
         }
     } else {
-        dependsOn publishArtifact
+        dependsOn publishArtifacts
     }
 }
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,9 +1,14 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.novoda:bintray-release:0.4.0'
+        classpath 'com.gradle.publish:plugin-publish-plugin:0.9.10'
+        classpath 'org.ajoberstar:gradle-git:1.6.0'
     }
 }
 


### PR DESCRIPTION
### Description
Scope of this PR is to prepare the release of version 0.4 including some changes around the automation like:
- automated release to the gradle plugins repo
- automated release of Groovydocs as github page
- automated github tag including the changelog from the latest version

Besides that I added some documentation for the release process.

The [jenkins job](https://ci.novoda.com/view/Open%20source/job/gradle-build-properties-plugin/) has been also updated to:
- trigger `publishRelease`
- include the `github` and `gradle plugins repo` credentials

This fixes:
- https://github.com/novoda/gradle-build-properties-plugin/issues/37
- https://github.com/novoda/gradle-build-properties-plugin/issues/21
- https://github.com/novoda/gradle-build-properties-plugin/issues/19

### Considerations
In this iteration I duplicated the [release script from the static analysis plugin](https://github.com/novoda/gradle-static-analysis-plugin/blob/master/gradle/publish.gradle) with some minor changes. As next step we will move this logic into it's own plugin so we can reuse it among all plugins.