### PR TITLE
Prepare changelog for v0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Change Log
 ==========
 
+[Version 0.4](https://github.com/novoda/gradle-build-properties-plugin/releases/tag/v0.4)
+--------------------------
+
+- Resolve build properties through project properties ([#PR48](https://github.com/novoda/gradle-build-properties-plugin/pull/48)).
+- Support chaining property sets ([#PR44](https://github.com/novoda/gradle-build-properties-plugin/pull/44)).
+- Support custom entry set implementations ([#PR42](https://github.com/novoda/gradle-build-properties-plugin/pull/42)).
+- Support maps in BuildProperties ([#PR25](https://github.com/novoda/gradle-build-properties-plugin/pull/25)).
+- Remove built-in signingConfig support ([#PR24](https://github.com/novoda/gradle-build-properties-plugin/pull/24)).
+- Use dynamic types in Android utility methods ([#PR23](https://github.com/novoda/gradle-build-properties-plugin/pull/23)).
+
 [Version 0.3](https://github.com/novoda/gradle-build-properties-plugin/releases/tag/v0.3)
 --------------------------
 


### PR DESCRIPTION
### Description
This PR updates the `changelog` for the release of v0.4.

Nest step is to merge `develop` into `master` to do the release.