### PR TITLE
Introduce fallback for deprecated file api

### DIFF
--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -3,16 +3,19 @@ package com.novoda.buildproperties
 import com.novoda.buildproperties.internal.DefaultEntriesFactory
 import com.novoda.buildproperties.internal.DefaultExceptionFactory
 import org.gradle.api.Project
+import org.gradle.api.logging.Logger
 
 class BuildProperties {
 
     private final String name
     private final DefaultEntriesFactory factory
+    private final Logger logger
     private EntriesChain chain
 
     BuildProperties(String name, Project project) {
         this.name = name
-        this.factory = new DefaultEntriesFactory(project.logger, new DefaultExceptionFactory(name))
+        this.logger = project.logger
+        this.factory = new DefaultEntriesFactory(logger, new DefaultExceptionFactory(name))
     }
 
     String getName() {
@@ -65,6 +68,23 @@ class BuildProperties {
 
     EntriesChain using(Project project) {
         newChain(project)
+    }
+
+    EntriesChain file(File file, String description = '') {
+        logger.warn("""/!\\ WARNING /!\\ Detected use of 'file' method to consume build properties from a file. 
+                       |                 This api is deprecated and will be removed in an upcoming release, please use using() instead.
+                       |                 For instance you could do:
+                       |                 
+                       |                    buildProperties {
+                       |                        using secrets.properties
+                       |                    }
+                       |
+                       |""".stripMargin())
+
+        if (!description.isEmpty()) {
+            setDescription description
+        }
+        newChain(file)
     }
 
     private EntriesChain newChain(def source) {

--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -70,6 +70,7 @@ class BuildProperties {
         newChain(project)
     }
 
+    @Deprecated
     EntriesChain file(File file, String description = '') {
         logger.warn("""/!\\ WARNING /!\\ Detected use of 'file' method to consume build properties from a file. 
                        |                 This api is deprecated and will be removed in an upcoming release, please use using() instead.

--- a/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/buildproperties/BuildPropertiesTest.groovy
@@ -140,6 +140,41 @@ class BuildPropertiesTest {
     }
 
     @Test
+    void shouldProvideSpecifiedErrorMessageWhenAccessingNonExistingPropertyUsingLegacyApi() {
+        File propertiesFile = newPropertiesFile('test.properties', 'd=value_d\ne=value_e\nf=value_f')
+
+        project.buildProperties {
+            test {
+                file(propertiesFile)
+            }
+        }
+
+        assertThat(project.buildProperties.test['d']).hasValue('value_d')
+        assertThat(project.buildProperties.test['e']).hasValue('value_e')
+        assertThat(project.buildProperties.test['f']).hasValue('value_f')
+    }
+
+    @Test
+    void shouldReturnPropertiesFileValuesUsingDeprecatedFileApi() {
+        File propertiesFile = newPropertiesFile('test.properties', 'd=value_d\ne=value_e\nf=value_f')
+
+        project.buildProperties {
+            test {
+                file(propertiesFile, "This is an error message")
+            }
+        }
+        
+        try {
+            project.buildProperties.test['a'].string
+            fail('Exception not thrown')
+        } catch (Exception e){
+            String message = e.getMessage()
+            assertThat(message).contains('Unable to find value for key \'a\' in properties set \'buildProperties.test\'.')
+            assertThat(message).contains('* buildProperties.test: This is an error message')
+        }
+    }
+
+    @Test
     void shouldReturnFallbackValuesWhenChainOfEntries() {
         File propertiesFile = newPropertiesFile('test.properties', 'd=value_d\ne=value_e\nf=value_f')
 


### PR DESCRIPTION
### Description
In order to to reduce the number of breaking changes for the upcoming release we decided to implement a fallback for the `file` api.

### Considerations
- introduced `BuildProperties.file(File file, String description)` which calls `using` and sets the description if needed
- log a warning that this method is deprecated

### Tests
- added a test to verify build properties can be consumed through legacy api
- added a test the description is set correctly through legacy api