### PR TITLE
Just trigger the bintrayUpload with a dry run

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -125,7 +125,9 @@ task publishRelease {
             }
         }
     } else {
-        dependsOn publishArtifacts
+        project.afterEvaluate {
+            dependsOn bintrayUpload
+        }
     }
 }
 


### PR DESCRIPTION
### Description
In case of a dry-run we still used to execute `bintrayUpload` which itself supports a dry-run. With my changes also `publishPlugins` has been executed with a dry-run, but failed since `prepareRelease` hasn't been executed.

### Considerations
- don't execute `publishPlugins` in case of a `dry-run`