### PR TITLE
Remove deprecated annotation on BuildProperties.file method

### DIFF
--- a/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
+++ b/plugin/src/main/groovy/com/novoda/buildproperties/BuildProperties.groovy
@@ -70,7 +70,6 @@ class BuildProperties {
         newChain(project)
     }
 
-    @Deprecated
     EntriesChain file(File file, String description = '') {
         logger.warn("""/!\\ WARNING /!\\ Detected use of 'file' method to consume build properties from a file. 
                        |                 This api is deprecated and will be removed in an upcoming release, please use using() instead.


### PR DESCRIPTION
Fixes #58

The PR will:
Remove the deprecated annotation on the BuildProperties.file method

Because:
There's a groovy/gradle issue where having this method deprecated will highlight the file() method on Project as deprecated